### PR TITLE
Implement -cionly flag to ignore context-dependent phones

### DIFF
--- a/include/soundswallower/bin_mdef.h
+++ b/include/soundswallower/bin_mdef.h
@@ -173,7 +173,7 @@ bin_mdef_t *bin_mdef_read(cmd_ln_t *config, const char *filename);
 /**
  * Read a binary mdef from an existing s3file_t.
  */
-bin_mdef_t *bin_mdef_read_s3file(s3file_t *s);
+bin_mdef_t *bin_mdef_read_s3file(s3file_t *s, int cionly);
 
 /**
  * Read a text mdef from a file (creating an in-memory binary mdef).

--- a/include/soundswallower/bin_mdef.h
+++ b/include/soundswallower/bin_mdef.h
@@ -207,16 +207,29 @@ int bin_mdef_ciphone_id_nocase(bin_mdef_t *m,	     /**< In: Model structure bein
 const char *bin_mdef_ciphone_str(bin_mdef_t *m,	/**< In: Model structure being queried */
 				 int32 ci);	/**< In: ciphone id for which name wanted */
 
-/* Return value: phone id for the given constituents if found, else -1 */
+/* Lookup an exact context-dependent phone ID.
+ *
+ * This returns *exactly* the context-dependent phone ID requested.
+ * If the context is completely undefined (-1, -1,
+ * WORD_POSN_UNDEFINED) then the base phone ID will be returned (but
+ * why would you do that?).  In nearly all cases, you should use
+ * bin_mdef_phone_id_nearest() instead.
+ *
+ * Return value: phone id for the given constituents if found, else -1
+ */
 int bin_mdef_phone_id(bin_mdef_t *m,	/**< In: Model structure being queried */
-		      int32 b,		/**< In: base ciphone id */
-		      int32 l,		/**< In: left context ciphone id */
-		      int32 r,		/**< In: right context ciphone id */
-		      int32 pos);	/**< In: Word position */
+		      int32 ci,		/**< In: base ciphone id */
+		      int32 l,		/**< In: left context ciphone id, -1 for none */
+		      int32 r,		/**< In: right context ciphone id, -1 for none */
+		      word_posn_t pos);	/**< In: Word position */
 
-/* Look up a phone id, backing off to other word positions. */
+/* Look up a phone id, backing off to other word positions.
+ *
+ * Note that if pos is WORD_POSN_UNDEFINED, this will try all
+ * positions and return the first one that matches.
+ */
 int bin_mdef_phone_id_nearest(bin_mdef_t * m, int32 b,
-			      int32 l, int32 r, int32 pos);
+			      int32 l, int32 r, word_posn_t pos);
 
 /**
  * Create a phone string for the given phone (base or triphone) id in the given buf.

--- a/include/soundswallower/cmdln_macro.h
+++ b/include/soundswallower/cmdln_macro.h
@@ -243,7 +243,11 @@
 { "-logbase",                                                                   \
       ARG_FLOATING,                                                              \
       "1.0001",                                                                 \
-      "Base in which all log-likelihoods calculated" }
+      "Base in which all log-likelihoods calculated" },                         \
+{ "-cionly",                                                                      \
+      ARG_BOOLEAN,                                                              \
+      "no",                                                                    \
+      "Use only context-independent phones (faster, useful for alignment)" }    \
 
 #define CMDLN_EMPTY_OPTION { NULL, 0, NULL, NULL }
 

--- a/include/soundswallower/cmdln_macro.h
+++ b/include/soundswallower/cmdln_macro.h
@@ -124,7 +124,7 @@
         "yes",                                                  \
         "Insert filler words at each state."}
 
-/** Command-line options for statistical language models. */
+/** Command-line options for statistical language models (not used) and grammars. */
 #define POCKETSPHINX_NGRAM_OPTIONS \
 { "-lw",										\
       ARG_FLOATING,									\

--- a/include/soundswallower/mdef.h
+++ b/include/soundswallower/mdef.h
@@ -182,9 +182,7 @@ typedef struct mdef_s {
  * It should be treated as a READ-ONLY structure.
  * @return pointer to the phone structure created.
  */
-mdef_t *mdef_init (char *mdeffile, /**< In: Model definition file */
-		   int breport     /**< In: whether to report the progress or not */
-    );
+mdef_t *mdef_init (char *mdeffile); /**< In: Model definition file */
 
 
 /** 

--- a/include/soundswallower/mdef.h
+++ b/include/soundswallower/mdef.h
@@ -182,7 +182,8 @@ typedef struct mdef_s {
  * It should be treated as a READ-ONLY structure.
  * @return pointer to the phone structure created.
  */
-mdef_t *mdef_init (char *mdeffile); /**< In: Model definition file */
+mdef_t *mdef_init (char *mdeffile, /**< In: Model definition file */
+                   int cionly);    /**< In: Read only context-independent phones */
 
 
 /** 

--- a/include/soundswallower/mdef.h
+++ b/include/soundswallower/mdef.h
@@ -248,10 +248,6 @@ int mdef_hmm_cmp (mdef_t *m,	/**< In: Model being queried */
                   int p2	/**< In: One of the two triphones being compared */
     );
 
-/** Report the model definition's parameters */
-void mdef_report(mdef_t *m /**<  In: model definition structure */
-    );
-
 /** RAH, For freeing memory */
 void mdef_free_recursive_lc (ph_lc_t *lc /**< In: A list of left context */
     );

--- a/js/api.js
+++ b/js/api.js
@@ -342,7 +342,7 @@ class Decoder {
 		s3f = await load_to_s3file(mdef_path);
 	    }
 	}
-	const mdef = Module._bin_mdef_read_s3file(s3f);
+	const mdef = Module._bin_mdef_read_s3file(s3f, 0);
 	Module._s3file_free(s3f);
 	if (mdef == 0)
 	    throw new Error("Failed to read mdef");

--- a/src/bin_mdef.c
+++ b/src/bin_mdef.c
@@ -308,13 +308,13 @@ bin_mdef_read(cmd_ln_t *config, const char *filename)
         return NULL;
     }
 
-    m = bin_mdef_read_s3file(s);
+    m = bin_mdef_read_s3file(s, cmd_ln_boolean_r(config, "-cionly"));
     s3file_free(s);
     return m;
 }
 
 EXPORT bin_mdef_t *
-bin_mdef_read_s3file(s3file_t *s)
+bin_mdef_read_s3file(s3file_t *s, int cionly)
 {
     size_t tree_start;
     int32 val, i;
@@ -368,6 +368,12 @@ bin_mdef_read_s3file(s3file_t *s)
     FREAD_SWAP32_CHK(&m->n_ctx);
     FREAD_SWAP32_CHK(&m->n_cd_tree);
     FREAD_SWAP32_CHK(&m->sil);
+
+    /* Remove CD phones if requested. */
+    if (cionly) {
+        m->n_phone = m->n_ciphone;
+        m->n_sen = m->n_ci_sen;
+    }
 
     /* CI names are first in the file. */
     m->ciname = ckd_calloc(m->n_ciphone, sizeof(*m->ciname));

--- a/src/bin_mdef.c
+++ b/src/bin_mdef.c
@@ -168,12 +168,12 @@ bin_mdef_read_text(cmd_ln_t *config, const char *filename)
 {
     bin_mdef_t *bmdef;
     mdef_t *mdef;
-    int i, nchars;
+    int i, nchars, cionly;
 
     (void)config;
 
-    if ((mdef = mdef_init((char *) filename,
-                          cmd_ln_boolean_r(config, "-cionly"))) == NULL)
+    cionly = (config == NULL) ? FALSE : cmd_ln_boolean_r(config, "-cionly");
+    if ((mdef = mdef_init((char *) filename, cionly)) == NULL)
         return NULL;
 
     /* Enforce some limits.  */
@@ -313,6 +313,7 @@ bin_mdef_read(cmd_ln_t *config, const char *filename)
 {
     bin_mdef_t *m;
     s3file_t *s;
+    int cionly;
 
     /* Try to read it as text first. */
     if ((m = bin_mdef_read_text(config, filename)) != NULL)
@@ -324,7 +325,8 @@ bin_mdef_read(cmd_ln_t *config, const char *filename)
         return NULL;
     }
 
-    m = bin_mdef_read_s3file(s, cmd_ln_boolean_r(config, "-cionly"));
+    cionly = (config == NULL) ? FALSE : cmd_ln_boolean_r(config, "-cionly");
+    m = bin_mdef_read_s3file(s, cionly);
     s3file_free(s);
     return m;
 }

--- a/src/bin_mdef.c
+++ b/src/bin_mdef.c
@@ -189,11 +189,9 @@ bin_mdef_read_text(cmd_ln_t *config, const char *filename)
         bmdef->cd_tree[i].ctx = i;
         bmdef->cd_tree[i].n_down = mdef->n_ciphone;
         bmdef->cd_tree[i].c.down = ci_idx;
-#if 0
-        E_INFO("%d => %c (%d@%d)\n",
-               i, (WPOS_NAME)[i],
-               bmdef->cd_tree[i].n_down, bmdef->cd_tree[i].c.down);
-#endif
+        E_DEBUG("%d => %c (%d@%d)\n",
+                i, (WPOS_NAME)[i],
+                bmdef->cd_tree[i].n_down, bmdef->cd_tree[i].c.down);
 
         /* Now we can build the rest of the tree. */
         for (j = 0; j < mdef->n_ciphone; ++j) {
@@ -210,16 +208,14 @@ bin_mdef_read_text(cmd_ln_t *config, const char *filename)
                     bmdef->cd_tree[rc_idx].ctx = rc->rc;
                     bmdef->cd_tree[rc_idx].n_down = 0;
                     bmdef->cd_tree[rc_idx].c.pid = rc->pid;
-#if 0
-                    E_INFO("%d => %s %s %s %c (%d@%d)\n",
-                           rc_idx,
-                           bmdef->ciname[j],
-                           bmdef->ciname[lc->lc],
-                           bmdef->ciname[rc->rc],
-                           (WPOS_NAME)[i],
-                           bmdef->cd_tree[rc_idx].n_down,
-                           bmdef->cd_tree[rc_idx].c.down);
-#endif
+                    E_DEBUG("%d => %s %s %s %c (%d@%d)\n",
+                            rc_idx,
+                            bmdef->ciname[j],
+                            bmdef->ciname[lc->lc],
+                            bmdef->ciname[rc->rc],
+                            (WPOS_NAME)[i],
+                            bmdef->cd_tree[rc_idx].n_down,
+                            bmdef->cd_tree[rc_idx].c.down);
 
                     ++bmdef->cd_tree[lc_idx].n_down;
                     ++rc_idx;
@@ -229,15 +225,13 @@ bin_mdef_read_text(cmd_ln_t *config, const char *filename)
                  * set the pid to -1. */
                 if (bmdef->cd_tree[lc_idx].n_down == 0)
                     bmdef->cd_tree[lc_idx].c.pid = -1;
-#if 0
-                E_INFO("%d => %s %s %c (%d@%d)\n",
-                       lc_idx,
-                       bmdef->ciname[j],
-                       bmdef->ciname[lc->lc],
-                       (WPOS_NAME)[i],
-                       bmdef->cd_tree[lc_idx].n_down,
-                       bmdef->cd_tree[lc_idx].c.down);
-#endif
+                E_DEBUG("%d => %s %s %c (%d@%d)\n",
+                        lc_idx,
+                        bmdef->ciname[j],
+                        bmdef->ciname[lc->lc],
+                        (WPOS_NAME)[i],
+                        bmdef->cd_tree[lc_idx].n_down,
+                        bmdef->cd_tree[lc_idx].c.down);
 
                 ++bmdef->cd_tree[ci_idx].n_down;
                 ++lc_idx;
@@ -246,12 +240,10 @@ bin_mdef_read_text(cmd_ln_t *config, const char *filename)
             /* As above, so below. */
             if (bmdef->cd_tree[ci_idx].n_down == 0)
                 bmdef->cd_tree[ci_idx].c.pid = -1;
-#if 0
-            E_INFO("%d => %d=%s (%d@%d)\n",
-                   ci_idx, j, bmdef->ciname[j],
-                   bmdef->cd_tree[ci_idx].n_down,
-                   bmdef->cd_tree[ci_idx].c.down);
-#endif
+            E_DEBUG("%d => %d=%s (%d@%d)\n",
+                    ci_idx, j, bmdef->ciname[j],
+                    bmdef->cd_tree[ci_idx].n_down,
+                    bmdef->cd_tree[ci_idx].c.down);
 
             ++ci_idx;
         }
@@ -609,28 +601,22 @@ bin_mdef_phone_id(bin_mdef_t * m, int32 ci, int32 lc, int32 rc, int32 wpos)
     while (level < 4) {
         int i;
 
-#if 0
-        E_INFO("Looking for context %d=%s in %d at %d\n",
-               ctx[level], m->ciname[ctx[level]],
-               max, cd_tree - m->cd_tree);
-#endif
+        E_DEBUG("Looking for context %d=%s in %d at %d\n",
+                ctx[level], m->ciname[ctx[level]],
+                max, cd_tree - m->cd_tree);
         for (i = 0; i < max; ++i) {
-#if 0
-            E_INFO("Look at context %d=%s at %d\n",
-                   cd_tree[i].ctx,
-                   m->ciname[cd_tree[i].ctx], cd_tree + i - m->cd_tree);
-#endif
+            E_DEBUG("Look at context %d=%s at %d\n",
+                    cd_tree[i].ctx,
+                    m->ciname[cd_tree[i].ctx], cd_tree + i - m->cd_tree);
             if (cd_tree[i].ctx == ctx[level])
                 break;
         }
         if (i == max)
             return -1;
-#if 0
-        E_INFO("Found context %d=%s at %d, n_down=%d, down=%d\n",
-               ctx[level], m->ciname[ctx[level]],
-               cd_tree + i - m->cd_tree,
-               cd_tree[i].n_down, cd_tree[i].c.down);
-#endif
+        E_DEBUG("Found context %d=%s at %d, n_down=%d, down=%d\n",
+                ctx[level], m->ciname[ctx[level]],
+                cd_tree + i - m->cd_tree,
+                cd_tree[i].n_down, cd_tree[i].c.down);
         /* Leaf node, stop here. */
         if (cd_tree[i].n_down == 0)
             return cd_tree[i].c.pid;

--- a/src/bin_mdef.c
+++ b/src/bin_mdef.c
@@ -70,7 +70,7 @@ bin_mdef_read_text(cmd_ln_t *config, const char *filename)
 
     (void)config;
 
-    if ((mdef = mdef_init((char *) filename, TRUE)) == NULL)
+    if ((mdef = mdef_init((char *) filename)) == NULL)
         return NULL;
 
     /* Enforce some limits.  */

--- a/src/mdef.c
+++ b/src/mdef.c
@@ -500,7 +500,7 @@ noncomment_line(char *line, int32 size, FILE * fp)
  * Initialize phones (ci and triphones) and state->senone mappings from .mdef file.
  */
 mdef_t *
-mdef_init(char *mdeffile, int32 breport)
+mdef_init(char *mdeffile)
 {
     FILE *fp;
     int32 n_ci, n_tri, n_map, n;
@@ -513,8 +513,7 @@ mdef_init(char *mdeffile, int32 breport)
     if (!mdeffile)
         E_FATAL("No mdef-file\n");
 
-    if (breport)
-        E_INFO("Reading model definition: %s\n", mdeffile);
+    E_INFO("Reading model definition: %s\n", mdeffile);
 
     m = (mdef_t *) ckd_calloc(1, sizeof(mdef_t));       /* freed in mdef_free */
 

--- a/src/mdef.c
+++ b/src/mdef.c
@@ -570,11 +570,25 @@ mdef_init(char *mdeffile, int cionly)
         || (m->n_ci_sen > m->n_sen))
         E_FATAL("%s: Error in header\n", mdeffile);
 
-    /* Check typesize limits */
+    /* This looks redundant at first glance but evidently we are
+     * checking that it divides with no remainder. */
+    m->n_emit_state = (n_map / (n_ci + n_tri)) - 1;
+    if ((m->n_emit_state + 1) * (n_ci + n_tri) != n_map)
+        E_FATAL
+            ("Header error: n_state_map not a multiple of n_ci*n_tri\n");
+
+    /* Truncate the mdef if requested */
+    if (cionly) {
+        n_tri = 0;
+        n_map = n_ci * m->n_emit_state;
+        m->n_sen = m->n_ci_sen;
+    }
+
+    /* Check typesize limits (FIXME: somewhat bogus) */
     if (n_ci >= MAX_INT16)
         E_FATAL("%s: #CI phones (%d) exceeds limit (%d)\n", mdeffile, n_ci,
                 MAX_INT16);
-    if (n_ci + n_tri >= MAX_INT32) /* Comparison is always false... */
+    if ((int64)n_ci + n_tri >= MAX_INT32)
         E_FATAL("%s: #Phones (%d) exceeds limit (%d)\n", mdeffile,
                 n_ci + n_tri, MAX_INT32);
     if (m->n_sen >= MAX_INT16)
@@ -584,10 +598,6 @@ mdef_init(char *mdeffile, int cionly)
         E_FATAL("%s: #tmats (%d) exceeds limit (%d)\n", mdeffile,
                 m->n_tmat, MAX_INT32);
 
-    m->n_emit_state = (n_map / (n_ci + n_tri)) - 1;
-    if ((m->n_emit_state + 1) * (n_ci + n_tri) != n_map)
-        E_FATAL
-            ("Header error: n_state_map not a multiple of n_ci*n_tri\n");
 
     /* Initialize ciphone info */
     m->n_ciphone = n_ci;
@@ -618,16 +628,22 @@ mdef_init(char *mdeffile, int cionly)
     }
     m->sil = mdef_ciphone_id(m, S3_SILENCE_CIPHONE);
 
-    /* Read triphones, if any */
+    /* Read triphones, if any  */
     for (; p < m->n_phone; p++) {
         if (noncomment_line(buf, sizeof(buf), fp) < 0)
             E_FATAL("Premature EOF reading phone %d\n", p);
         parse_tri_line(m, buf, p);
     }
 
-    if (noncomment_line(buf, sizeof(buf), fp) >= 0)
-        E_ERROR("Non-empty file beyond expected #phones (%d)\n",
-                m->n_phone);
+    /* Check for extra stuff, unless we explicitly asked to truncate. */
+    if (!cionly) {
+        if (noncomment_line(buf, sizeof(buf), fp) >= 0) {
+            E_ERROR("Non-empty file beyond expected #phones (%d)\n",
+                    m->n_phone);
+            mdef_free(m);
+            return NULL;
+        }
+    }
 
     /* Build CD senones to CI senones map */
     if (m->n_ciphone * m->n_emit_state != m->n_ci_sen)
@@ -656,27 +672,15 @@ mdef_init(char *mdeffile, int cionly)
     sseq_compress(m);
     fclose(fp);
 
+    E_INFO("%d CI-phone, %d CD-phone, %d emitstate/phone, %d CI-sen, %d Sen, %d Sen-Seq\n",
+           m->n_ciphone, m->n_phone - m->n_ciphone, m->n_emit_state,
+           m->n_ci_sen, m->n_sen, m->n_sseq);
     return m;
-}
-
-void
-mdef_report(mdef_t * m)
-{
-    E_INFO_NOFN("Initialization of mdef_t, report:\n");
-    E_INFO_NOFN
-        ("%d CI-phone, %d CD-phone, %d emitstate/phone, %d CI-sen, %d Sen, %d Sen-Seq\n",
-         m->n_ciphone, m->n_phone - m->n_ciphone, m->n_emit_state,
-         m->n_ci_sen, m->n_sen, m->n_sseq);
-    E_INFO_NOFN("\n");
-
 }
 
 /* RAH 4.23.01, Need to step down the ->next list to see if there are
    any more things to free
  */
-
-
-
 /* RAH 4.19.01, Attempt to free memory that was allocated within this module
    I have not verified that all the memory has been freed. I've taken only a 
    reasonable effort for now.

--- a/src/mdef.c
+++ b/src/mdef.c
@@ -500,7 +500,7 @@ noncomment_line(char *line, int32 size, FILE * fp)
  * Initialize phones (ci and triphones) and state->senone mappings from .mdef file.
  */
 mdef_t *
-mdef_init(char *mdeffile)
+mdef_init(char *mdeffile, int cionly)
 {
     FILE *fp;
     int32 n_ci, n_tri, n_map, n;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ set(TESTS
   test_heap.c
   test_jsgf.c
   test_listelem_alloc.c
+  test_mdef.c
   test_log_shifted.c
   test_pitch.c
   test_ptm_mgau.c

--- a/tests/test_mdef.c
+++ b/tests/test_mdef.c
@@ -1,0 +1,189 @@
+#include "config.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#include <soundswallower/pocketsphinx.h>
+#include <soundswallower/bin_mdef.h>
+#include <soundswallower/err.h>
+
+#include "test_macros.h"
+
+/* Test context-dependent phone lookup. */
+void
+test_cd_mdef(bin_mdef_t *mdef)
+{
+    /* Ask for CI phone, get CI phone. */
+    TEST_EQUAL(5, bin_mdef_phone_id(mdef,
+                                    bin_mdef_ciphone_id(mdef, "AO"),
+                                    -1, -1, WORD_POSN_UNDEFINED));
+    /* Ask for something impossible, get -1. */
+    TEST_EQUAL(-1, bin_mdef_phone_id(mdef,
+                                    bin_mdef_ciphone_id(mdef, "ZH"),
+                                    bin_mdef_ciphone_id(mdef, "ZH"),
+                                    bin_mdef_ciphone_id(mdef, "ZH"),
+                                    WORD_POSN_SINGLE));
+    /* Ask for something possible, get it. */
+    TEST_EQUAL(42, bin_mdef_phone_id(mdef,
+                                    bin_mdef_ciphone_id(mdef, "AA"),
+                                    bin_mdef_ciphone_id(mdef, "AA"),
+                                    bin_mdef_ciphone_id(mdef, "AA"),
+                                    WORD_POSN_SINGLE));
+    TEST_EQUAL(121854, bin_mdef_phone_id(mdef,
+                                         bin_mdef_ciphone_id(mdef, "UW"),
+                                         bin_mdef_ciphone_id(mdef, "F"),
+                                         bin_mdef_ciphone_id(mdef, "B"),
+                                         WORD_POSN_END));
+    TEST_EQUAL(137094, bin_mdef_phone_id(mdef,
+                                         bin_mdef_ciphone_id(mdef, "ZH"),
+                                         bin_mdef_ciphone_id(mdef, "ZH"),
+                                         bin_mdef_ciphone_id(mdef, "W"),
+                                         WORD_POSN_BEGIN));
+    /* Back off to CI phone (should do something smarter, but really, no). */
+    TEST_EQUAL(41,
+               bin_mdef_phone_id_nearest(mdef,
+                                         bin_mdef_ciphone_id(mdef, "ZH"),
+                                         bin_mdef_ciphone_id(mdef, "ZH"),
+                                         bin_mdef_ciphone_id(mdef, "ZH"),
+                                         WORD_POSN_SINGLE));
+    /* Back off to silence context. */
+    TEST_EQUAL(137005,
+               bin_mdef_phone_id_nearest(mdef,
+                                         bin_mdef_ciphone_id(mdef, "ZH"),
+                                         bin_mdef_ciphone_id(mdef, "UW"),
+                                         bin_mdef_ciphone_id(mdef, "+NSN+"),
+                                         WORD_POSN_END));
+}
+
+/* Test context-independent phone lookup. */
+void
+test_ci_mdef(bin_mdef_t *mdef)
+{
+    TEST_EQUAL(2, bin_mdef_ciphone_id(mdef, "AA"));
+    TEST_EQUAL(5, bin_mdef_ciphone_id(mdef, "AO"));
+    TEST_EQUAL(41, bin_mdef_ciphone_id(mdef, "ZH"));
+    TEST_EQUAL(2, bin_mdef_ciphone_id_nocase(mdef, "Aa"));
+    TEST_EQUAL(41, bin_mdef_ciphone_id_nocase(mdef, "zH"));
+    TEST_EQUAL(5, bin_mdef_ciphone_id_nocase(mdef, "ao"));
+    TEST_EQUAL(41, bin_mdef_ciphone_id_nocase(mdef, "zh"));
+    TEST_EQUAL(41, bin_mdef_ciphone_id_nocase(mdef, "ZH"));
+    TEST_EQUAL(0, strcmp("ZH",
+                          bin_mdef_ciphone_str(mdef, bin_mdef_ciphone_id(mdef, "ZH"))));
+    TEST_EQUAL(0, strcmp("AO",
+                         bin_mdef_ciphone_str(mdef, bin_mdef_ciphone_id(mdef, "AO"))));
+
+    TEST_EQUAL(5, bin_mdef_phone_id(mdef,
+                                    bin_mdef_ciphone_id(mdef, "AO"),
+                                    -1, -1, WORD_POSN_UNDEFINED));
+}
+
+/* Test forced context-independent phone lookup. */
+void
+test_cionly_mdef(bin_mdef_t *mdef)
+{
+    /* Ask for CI phone, get CI phone. */
+    TEST_EQUAL(5, bin_mdef_phone_id(mdef,
+                                    bin_mdef_ciphone_id(mdef, "AO"),
+                                    -1, -1, WORD_POSN_UNDEFINED));
+    /* Ask for something impossible, get -1. */
+    TEST_EQUAL(-1, bin_mdef_phone_id(mdef,
+                                    bin_mdef_ciphone_id(mdef, "ZH"),
+                                    bin_mdef_ciphone_id(mdef, "ZH"),
+                                    bin_mdef_ciphone_id(mdef, "ZH"),
+                                    WORD_POSN_SINGLE));
+    /* Exact match is always impossible with no CD phones. */
+    TEST_EQUAL(-1, 
+               bin_mdef_phone_id(mdef,
+                                 bin_mdef_ciphone_id(mdef, "AA"),
+                                 bin_mdef_ciphone_id(mdef, "AA"),
+                                 bin_mdef_ciphone_id(mdef, "AA"),
+                                 WORD_POSN_SINGLE));
+    TEST_EQUAL(-1,
+               bin_mdef_phone_id(mdef,
+                                 bin_mdef_ciphone_id(mdef, "UW"),
+                                 bin_mdef_ciphone_id(mdef, "F"),
+                                 bin_mdef_ciphone_id(mdef, "B"),
+                                 WORD_POSN_END));
+    TEST_EQUAL(-1,
+               bin_mdef_phone_id(mdef,
+                                 bin_mdef_ciphone_id(mdef, "ZH"),
+                                 bin_mdef_ciphone_id(mdef, "ZH"),
+                                 bin_mdef_ciphone_id(mdef, "W"),
+                                 WORD_POSN_BEGIN));
+    /* Nearest match always gives CI phone */
+    TEST_EQUAL(bin_mdef_ciphone_id(mdef, "AA"),
+               bin_mdef_phone_id_nearest(mdef,
+                                 bin_mdef_ciphone_id(mdef, "AA"),
+                                 bin_mdef_ciphone_id(mdef, "AA"),
+                                 bin_mdef_ciphone_id(mdef, "AA"),
+                                 WORD_POSN_SINGLE));
+    TEST_EQUAL(bin_mdef_ciphone_id(mdef, "UW"),
+               bin_mdef_phone_id_nearest(mdef,
+                                 bin_mdef_ciphone_id(mdef, "UW"),
+                                 bin_mdef_ciphone_id(mdef, "F"),
+                                 bin_mdef_ciphone_id(mdef, "B"),
+                                 WORD_POSN_END));
+    TEST_EQUAL(bin_mdef_ciphone_id(mdef, "ZH"),
+               bin_mdef_phone_id_nearest(mdef,
+                                 bin_mdef_ciphone_id(mdef, "ZH"),
+                                 bin_mdef_ciphone_id(mdef, "ZH"),
+                                 bin_mdef_ciphone_id(mdef, "W"),
+                                 WORD_POSN_BEGIN));
+    TEST_EQUAL(bin_mdef_ciphone_id(mdef, "ZH"),
+               bin_mdef_phone_id_nearest(mdef,
+                                         bin_mdef_ciphone_id(mdef, "ZH"),
+                                         bin_mdef_ciphone_id(mdef, "ZH"),
+                                         bin_mdef_ciphone_id(mdef, "ZH"),
+                                         WORD_POSN_SINGLE));
+    TEST_EQUAL(bin_mdef_ciphone_id(mdef, "ZH"),
+               bin_mdef_phone_id_nearest(mdef,
+                                         bin_mdef_ciphone_id(mdef, "ZH"),
+                                         bin_mdef_ciphone_id(mdef, "UW"),
+                                         bin_mdef_ciphone_id(mdef, "+NSN+"),
+                                         WORD_POSN_END));
+}
+
+int
+main(int argc, char *argv[])
+{
+    cmd_ln_t *config;
+    bin_mdef_t *mdef;
+    
+    (void)argc; (void)argv;
+    err_set_loglevel(ERR_INFO);
+    config = cmd_ln_init(NULL, ps_args(), TRUE, NULL);
+
+    E_INFO("Testing text mdef read\n");
+    mdef = bin_mdef_read(config, MODELDIR "/en-us/mdef.txt");
+    TEST_ASSERT(mdef != NULL);
+    test_ci_mdef(mdef);
+    test_cd_mdef(mdef);
+    bin_mdef_free(mdef);
+
+    E_INFO("Testing text mdef -cionly read\n");
+    cmd_ln_set_boolean_r(config, "-cionly", TRUE);
+    mdef = bin_mdef_read(config, MODELDIR "/en-us/mdef.txt");
+    TEST_ASSERT(mdef != NULL);
+    test_ci_mdef(mdef);
+    test_cionly_mdef(mdef);
+    bin_mdef_free(mdef);
+
+    E_INFO("Testing binary mdef read\n");
+    cmd_ln_set_boolean_r(config, "-cionly", FALSE);
+    mdef = bin_mdef_read(config, MODELDIR "/en-us/mdef.bin");
+    TEST_ASSERT(mdef != NULL);
+    test_ci_mdef(mdef);
+    test_cd_mdef(mdef);
+    bin_mdef_free(mdef);
+
+    E_INFO("Testing binary mdef -cionly read\n");
+    cmd_ln_set_boolean_r(config, "-cionly", TRUE);
+    mdef = bin_mdef_read(config, MODELDIR "/en-us/mdef.bin");
+    TEST_ASSERT(mdef != NULL);
+    test_ci_mdef(mdef);
+    test_cionly_mdef(mdef);
+    bin_mdef_free(mdef);
+
+    cmd_ln_free_r(config);
+    return 0;
+}


### PR DESCRIPTION
Can be useful for force alignment as it is faster and not really less accurate for that use case.