### PR TITLE
Allow mixed float32 and int16 inputs

### DIFF
--- a/include/soundswallower/fe.h
+++ b/include/soundswallower/fe.h
@@ -331,21 +331,6 @@ void fe_get_input_size(fe_t *fe, int *out_frame_shift,
  */
 int fe_start(fe_t *fe);
 
-/**
- * Finish processing.
- *
- * This function also collects any remaining samples and calculates a
- * final cepstral vector, if present.  If there are overflow samples
- * remaining, it will pad with zeros to make a complete frame.
- *
- * @param fe Front-end object.
- * @param buf_cep Cepstral buffer as passed to fe_process().
- * @param inout_nframes Number of frames available, will be updated
- *                      with number written.
- * @return number of frames written, <0 for error (see enum fe_error_e)
- */
-int fe_end(fe_t *fe, mfcc_t **buf_cep, int *inout_nframes);
-
 /** 
  * Process a block of samples.
  *
@@ -415,6 +400,24 @@ int fe_process_float32(fe_t *fe,
                        size_t *inout_nsamps,
                        mfcc_t **buf_cep,
                        int *inout_nframes);
+
+/**
+ * Finish processing.
+ *
+ * This function collects any remaining samples and calculates a final
+ * cepstral vector, if present.  If there are overflow samples
+ * remaining, it will pad with zeros to make a complete frame.
+ *
+ * @param fe Front-end object.
+ * @param buf_cep Cepstral buffer as passed to fe_process().
+ * @param inout_nframes Number of frames available in buf_cep, will be
+ *                      updated with number remaining after writing,
+ *                      as in fe_process().
+ * @return number of frames written (always 0 or 1), <0 for error (see
+ *         enum fe_error_e)
+ */
+int fe_end(fe_t *fe, mfcc_t **buf_cep, int *inout_nframes);
+
 
 /**
  * Process one frame of log spectra into MFCC using discrete cosine

--- a/include/soundswallower/fe.h
+++ b/include/soundswallower/fe.h
@@ -361,6 +361,7 @@ int fe_start(fe_t *fe);
  *         // Now do something with these frames...
  *         if (nvec > 0)
  *             do_some_stuff(mfcc, nvec);
+ *     }
  *     nvec = fe_end(fe, mfcc, &nframes);
  *     if (nvec > 0)
  *         do_some_stuff(mfcc, nvec);
@@ -383,7 +384,7 @@ int fe_start(fe_t *fe);
  *                      including any frames output by fe_end().
  * @return number of frames written, or <0 on error (see fe_error_e)
  */
-int fe_process(fe_t *fe,
+int fe_process_int16(fe_t *fe,
                int16 const **inout_spch,
                size_t *inout_nsamps,
                mfcc_t **buf_cep,
@@ -392,7 +393,7 @@ int fe_process(fe_t *fe,
 /** 
  * Process a block of floating-point samples.
  *
- * See fe_process(), except that the input is expected to be
+ * See fe_process_int16(), except that the input is expected to be
  * 32-bit floating point in the range of [-1.0, 1.0].
  */
 int fe_process_float32(fe_t *fe,

--- a/include/soundswallower/fe.h
+++ b/include/soundswallower/fe.h
@@ -339,12 +339,12 @@ int fe_start(fe_t *fe);
  * remaining, it will pad with zeros to make a complete frame.
  *
  * @param fe Front-end object.
- * @param out_cepvector Cepstral buffer as passed to fe_process().
+ * @param buf_cep Cepstral buffer as passed to fe_process().
  * @param inout_nframes Number of frames available, will be updated
  *                      with number written.
  * @return number of frames written, <0 for error (see enum fe_error_e)
  */
-int fe_end(fe_t *fe, mfcc_t **out_cepvector, int *inout_nframes);
+int fe_end(fe_t *fe, mfcc_t **buf_cep, int *inout_nframes);
 
 /** 
  * Process a block of samples.

--- a/include/soundswallower/fe.h
+++ b/include/soundswallower/fe.h
@@ -298,7 +298,7 @@ cmd_ln_t *fe_get_config(fe_t *fe);
  * Get the dimensionality of the output of this front-end object.
  *
  * This is guaranteed to be the number of values in one frame of
- * output from fe_end_utt(), fe_process_frame(), and
+ * output from fe_end(), fe_process_frame(), and
  * fe_process_frames().  It is usually the number of MFCC
  * coefficients, but it might be the number of log-spectrum bins, if
  * the <tt>-logspec</tt> or <tt>-smoothspec</tt> options to
@@ -339,13 +339,12 @@ int fe_start(fe_t *fe);
  * remaining, it will pad with zeros to make a complete frame.
  *
  * @param fe Front-end object.
- * @param out_cepvector Buffer to hold a residual cepstral vector,
- *                      or NULL if you wish to ignore it.
+ * @param out_cepvector Cepstral buffer as passed to fe_process().
  * @param inout_nframes Number of frames available, will be updated
  *                      with number written.
  * @return number of frames written, <0 for error (see enum fe_error_e)
  */
-int fe_end(fe_t *fe, mfcc_t *out_cepvector, int *inout_nframes);
+int fe_end(fe_t *fe, mfcc_t **out_cepvector, int *inout_nframes);
 
 /** 
  * Process a block of samples.

--- a/include/soundswallower/fe.h
+++ b/include/soundswallower/fe.h
@@ -260,6 +260,14 @@ enum fe_error_e {
 };
 
 /**
+ * Encodings for input data.
+ */
+typedef enum fe_encoding_e {
+    FE_PCM16,
+    FE_FLOAT32
+} fe_encoding_t;
+
+/**
  * Initialize a front-end object from a command-line parse.
  *
  * @param config Command-line object, as returned by cmd_ln_parse_r()

--- a/include/soundswallower/fe_internal.h
+++ b/include/soundswallower/fe_internal.h
@@ -99,6 +99,11 @@ struct melfb_s {
 /* sqrt(1/2), also used for unitary DCT-II/DCT-III */
 #define SQRT_HALF FLOAT2MFCC(0.707106781186548)
 
+/* Scale for float data. */
+#define FLOAT32_SCALE 32768.0
+/* Dithering constant for float data. */
+#define FLOAT32_DITHER 1.0
+
 /** Structure for the front-end computation. */
 struct fe_s {
     cmd_ln_t *config;
@@ -132,36 +137,30 @@ struct fe_s {
     /* Half of a Hamming Window. */
     window_t *hamming_window;
 
-    /* Temporary buffers for processing. */
-    union {
-        int16 *s_int16;
-        float32 *s_float32;
-    } spch;
-    frame_t *frame;
-    powspec_t *spec, *mfspec;
-    union {
-        int16 *s_int16;
-        float32 *s_float32;
-    } overflow_samps;
+    /* One frame's worth of PCM data. */
+    float32 *spch;
+    /* One frame's worth of extra PCM data. */
+    float32 *overflow_samps;
+    /* How many extra samples there are. */
     int num_overflow_samps;    
-    union {
-        int16 s_int16;
-        float32 s_float32;
-    } pre_emphasis_prior;
-    int is_float32;
-    /* Noise removal */
+    /* One frame's worth of waveform. */
+    frame_t *frame;
+    /* Spectrum and mel-spectrum. */
+    powspec_t *spec, *mfspec;
+    /* Carryover value from previous frame for pre-emphasis filter. */
+    float32 pre_emphasis_prior;
+
+    /* Noise removal parameters and buffers. */
     noise_stats_t *noise_stats;
 };
 
 void fe_init_dither(int32 seed);
 
 /* Load a frame of data into the fe. */
-//int fe_read_frame(fe_t *fe, int16 const *in, int32 len);
 int fe_read_frame_int16(fe_t *fe, int16 const *in, int32 len);
 int fe_read_frame_float32(fe_t *fe, float32 const *in, int32 len);
 
 /* Shift the input buffer back and read more data. */
-//int fe_shift_frame(fe_t *fe, int16 const *in, int32 len);
 int fe_shift_frame_int16(fe_t *fe, int16 const *in, int32 len);
 int fe_shift_frame_float32(fe_t *fe, float32 const *in, int32 len);
 

--- a/src/acmod.c
+++ b/src/acmod.c
@@ -308,7 +308,7 @@ acmod_set_grow(acmod_t *acmod, int grow_feat)
 int
 acmod_start_utt(acmod_t *acmod)
 {
-    fe_start_utt(acmod->fe);
+    fe_start(acmod->fe);
     acmod->state = ACMOD_STARTED;
     acmod->n_mfc_frame = 0;
     acmod->n_feat_frame = 0;
@@ -332,7 +332,7 @@ acmod_end_utt(acmod_t *acmod)
         /* Where to start writing them (circular buffer) */
         inptr = (acmod->mfc_outidx + acmod->n_mfc_frame) % acmod->n_mfc_alloc;
         nfr = acmod->n_mfc_alloc - inptr;
-        ntail = fe_end_utt(acmod->fe, acmod->mfc_buf[inptr], &nfr);
+        ntail = fe_end(acmod->fe, acmod->mfc_buf[inptr], &nfr);
         acmod->n_mfc_frame += ntail;
         /* Process whatever's left, and any leadout. */
         if (ntail)
@@ -391,11 +391,11 @@ acmod_process_full_raw(acmod_t *acmod,
     }
     acmod->n_mfc_frame = 0;
     acmod->mfc_outidx = 0;
-    fe_start_utt(acmod->fe);
+    fe_start(acmod->fe);
     if ((nvec = fe_process(acmod->fe, inout_raw, inout_n_samps,
                            acmod->mfc_buf, &nfr)) < 0)
         return -1;
-    ntail = fe_end_utt(acmod->fe, acmod->mfc_buf[nvec], &nfr);
+    ntail = fe_end(acmod->fe, acmod->mfc_buf[nvec], &nfr);
     nvec += ntail;
 
     cepptr = acmod->mfc_buf;
@@ -425,12 +425,12 @@ acmod_process_full_float32(acmod_t *acmod,
     }
     acmod->n_mfc_frame = 0;
     acmod->mfc_outidx = 0;
-    fe_start_utt(acmod->fe);
+    fe_start(acmod->fe);
     if ((nvec = fe_process_float32(acmod->fe,
                                    inout_raw, inout_n_samps,
                                    acmod->mfc_buf, &nfr)) < 0)
         return -1;
-    ntail = fe_end_utt(acmod->fe, acmod->mfc_buf[nvec], &nfr);
+    ntail = fe_end(acmod->fe, acmod->mfc_buf[nvec], &nfr);
     nvec += ntail;
 
     cepptr = acmod->mfc_buf;

--- a/src/acmod.c
+++ b/src/acmod.c
@@ -381,7 +381,7 @@ acmod_process_full_raw(acmod_t *acmod,
     mfcc_t **cepptr;
 
     /* Resize mfc_buf to fit. */
-    if (fe_process(acmod->fe, NULL, inout_n_samps, NULL, &nfr) < 0)
+    if (fe_process_int16(acmod->fe, NULL, inout_n_samps, NULL, &nfr) < 0)
         return -1;
     if (acmod->n_mfc_alloc < nfr + 1) {
         ckd_free_2d(acmod->mfc_buf);
@@ -392,7 +392,7 @@ acmod_process_full_raw(acmod_t *acmod,
     acmod->n_mfc_frame = 0;
     acmod->mfc_outidx = 0;
     fe_start(acmod->fe);
-    if ((nvec = fe_process(acmod->fe, inout_raw, inout_n_samps,
+    if ((nvec = fe_process_int16(acmod->fe, inout_raw, inout_n_samps,
                            acmod->mfc_buf, &nfr)) < 0)
         return -1;
     ntail = fe_end(acmod->fe, acmod->mfc_buf + nvec, &nfr);
@@ -501,7 +501,7 @@ acmod_process_raw(acmod_t *acmod,
         /* Write them in two (or more) parts if there is wraparound. */
         while (inptr + ncep > acmod->n_mfc_alloc) {
             int ncep1 = acmod->n_mfc_alloc - inptr;
-            if ((nvec = fe_process(acmod->fe, inout_raw, inout_n_samps,
+            if ((nvec = fe_process_int16(acmod->fe, inout_raw, inout_n_samps,
                                    acmod->mfc_buf + inptr, &ncep1)) < 0)
                 return -1;
             /* nvec contains the number of frames actually processed.
@@ -518,7 +518,7 @@ acmod_process_raw(acmod_t *acmod,
         	goto alldone;
         }
         assert(inptr + ncep <= acmod->n_mfc_alloc);
-        if ((nvec = fe_process(acmod->fe, inout_raw, inout_n_samps,
+        if ((nvec = fe_process_int16(acmod->fe, inout_raw, inout_n_samps,
                                acmod->mfc_buf + inptr, &ncep)) < 0)
             return -1;
         acmod->n_mfc_frame += nvec;

--- a/src/acmod.c
+++ b/src/acmod.c
@@ -324,7 +324,7 @@ acmod_start_utt(acmod_t *acmod)
 int
 acmod_end_utt(acmod_t *acmod)
 {
-    int32 ntail;
+    int32 ntail = 0;
 
     acmod->state = ACMOD_ENDED;
     if (acmod->n_mfc_frame < acmod->n_mfc_alloc) {

--- a/src/acmod.c
+++ b/src/acmod.c
@@ -332,7 +332,7 @@ acmod_end_utt(acmod_t *acmod)
         /* Where to start writing them (circular buffer) */
         inptr = (acmod->mfc_outidx + acmod->n_mfc_frame) % acmod->n_mfc_alloc;
         nfr = acmod->n_mfc_alloc - inptr;
-        ntail = fe_end(acmod->fe, acmod->mfc_buf[inptr], &nfr);
+        ntail = fe_end(acmod->fe, acmod->mfc_buf + inptr, &nfr);
         acmod->n_mfc_frame += ntail;
         /* Process whatever's left, and any leadout. */
         if (ntail)
@@ -395,7 +395,7 @@ acmod_process_full_raw(acmod_t *acmod,
     if ((nvec = fe_process(acmod->fe, inout_raw, inout_n_samps,
                            acmod->mfc_buf, &nfr)) < 0)
         return -1;
-    ntail = fe_end(acmod->fe, acmod->mfc_buf[nvec], &nfr);
+    ntail = fe_end(acmod->fe, acmod->mfc_buf + nvec, &nfr);
     nvec += ntail;
 
     cepptr = acmod->mfc_buf;
@@ -430,7 +430,7 @@ acmod_process_full_float32(acmod_t *acmod,
                                    inout_raw, inout_n_samps,
                                    acmod->mfc_buf, &nfr)) < 0)
         return -1;
-    ntail = fe_end(acmod->fe, acmod->mfc_buf[nvec], &nfr);
+    ntail = fe_end(acmod->fe, acmod->mfc_buf + nvec, &nfr);
     nvec += ntail;
 
     cepptr = acmod->mfc_buf;

--- a/src/fe_interface.c
+++ b/src/fe_interface.c
@@ -653,10 +653,10 @@ fe_process_int16(fe_t *fe,
 
 int
 fe_process(fe_t *fe,
-                  int16 const **inout_spch,
-                  size_t *inout_nsamps,
-                  mfcc_t **buf_cep,
-                  int32 *inout_nframes)
+           int16 const **inout_spch,
+           size_t *inout_nsamps,
+           mfcc_t **buf_cep,
+           int32 *inout_nframes)
 {
     return fe_process_int16(fe, inout_spch, inout_nsamps,
                             buf_cep, inout_nframes);

--- a/src/fe_interface.c
+++ b/src/fe_interface.c
@@ -663,17 +663,17 @@ fe_process(fe_t *fe,
 }
 
 int
-fe_end(fe_t *fe, mfcc_t **cepvector, int *nframes)
+fe_end(fe_t *fe, mfcc_t **buf_cep, int *nframes)
 {
     int nfr = 0;
     
     /* Process any remaining data if possible. */
-    if (cepvector && nframes
+    if (buf_cep && nframes
         && *nframes > 0
         && fe->num_overflow_samps > 0) {
         fe_read_frame_float32(fe, fe->overflow_samps,
                               fe->num_overflow_samps);
-        fe_write_frame(fe, *cepvector);
+        fe_write_frame(fe, *buf_cep);
         nfr = 1;
         if (nframes)
             *nframes -= nfr;

--- a/src/fe_interface.c
+++ b/src/fe_interface.c
@@ -663,7 +663,7 @@ fe_process(fe_t *fe,
 }
 
 int
-fe_end(fe_t *fe, mfcc_t *cepvector, int *nframes)
+fe_end(fe_t *fe, mfcc_t **cepvector, int *nframes)
 {
     int nfr = 0;
     
@@ -673,7 +673,7 @@ fe_end(fe_t *fe, mfcc_t *cepvector, int *nframes)
         && fe->num_overflow_samps > 0) {
         fe_read_frame_float32(fe, fe->overflow_samps,
                               fe->num_overflow_samps);
-        fe_write_frame(fe, cepvector);
+        fe_write_frame(fe, *cepvector);
         nfr = 1;
         if (nframes)
             *nframes -= nfr;

--- a/src/fe_interface.c
+++ b/src/fe_interface.c
@@ -84,7 +84,6 @@ fe_parse_general_params(cmd_ln_t *config, fe_t * fe)
 
     fe->num_cepstra = (uint8)cmd_ln_int32_r(config, "-ncep");
     fe->fft_size = (int16)cmd_ln_int32_r(config, "-nfft");
-    fe->is_float32 = cmd_ln_boolean_r(config, "-input_float32");
 
     window_samples = (int)(fe->window_length * fe->sampling_rate);
     E_INFO("Frames are %d samples at intervals of %d\n",
@@ -232,7 +231,7 @@ fe_init(cmd_ln_t *config)
      */
     fe->frame_shift = (int32) (fe->sampling_rate / fe->frame_rate + 0.5);
     fe->frame_size = (int32) (fe->window_length * fe->sampling_rate + 0.5);
-    fe->pre_emphasis_prior.s_float32 = 0;
+    fe->pre_emphasis_prior = 0;
 
     assert (fe->frame_shift > 1);
     if (fe->frame_size < fe->frame_shift) {
@@ -255,7 +254,7 @@ fe_init(cmd_ln_t *config)
         fe_init_dither(fe->dither_seed);
 
     /* establish buffers for overflow samps and hamming window */
-    fe->overflow_samps.s_float32 = ckd_calloc(fe->frame_size, sizeof(float32));
+    fe->overflow_samps = ckd_calloc(fe->frame_size, sizeof(float32));
     fe->hamming_window = ckd_calloc(fe->frame_size/2, sizeof(window_t));
 
     /* create hamming window */
@@ -281,7 +280,7 @@ fe_init(cmd_ln_t *config)
 
     /* Create temporary FFT, spectrum and mel-spectrum buffers. */
     /* FIXME: Gosh there are a lot of these. */
-    fe->spch.s_float32 = ckd_calloc(fe->frame_size, sizeof(*fe->spch.s_float32));
+    fe->spch = ckd_calloc(fe->frame_size, sizeof(*fe->spch));
     fe->frame = ckd_calloc(fe->fft_size, sizeof(*fe->frame));
     fe->spec = ckd_calloc(fe->fft_size, sizeof(*fe->spec));
     fe->mfspec = ckd_calloc(fe->mel_fb->num_filters, sizeof(*fe->mfspec));
@@ -323,17 +322,9 @@ int32
 fe_start_utt(fe_t * fe)
 {
     fe->num_overflow_samps = 0;
-    if (fe->is_float32) {
-        memset(fe->overflow_samps.s_float32, 0,
-               fe->frame_size * sizeof(*fe->overflow_samps.s_float32));
-        fe->pre_emphasis_prior.s_float32 = 0;
-    }
-    else {
-        // Does the same thing as above, but whatever...
-        memset(fe->overflow_samps.s_int16, 0,
-               fe->frame_size * sizeof(*fe->overflow_samps.s_int16));
-        fe->pre_emphasis_prior.s_int16 = 0;
-    }
+    memset(fe->overflow_samps, 0,
+           fe->frame_size * sizeof(*fe->overflow_samps));
+    fe->pre_emphasis_prior = 0;
     fe_reset_noisestats(fe->noise_stats);
     return 0;
 }
@@ -354,233 +345,350 @@ fe_get_input_size(fe_t *fe, int *out_frame_shift,
         *out_frame_size = fe->frame_size;
 }
 
-int32
-fe_process_frame(fe_t * fe, int16 const *spch, int32 nsamps, mfcc_t * fr_cep)
+int
+fe_process_float32(fe_t *fe,
+                   float32 const **inout_spch,
+                   size_t *inout_nsamps,
+                   mfcc_t **buf_cep,
+                   int32 *inout_nframes)
 {
-    fe_read_frame_int16(fe, spch, nsamps);
-    return fe_write_frame(fe, fr_cep);
-}
+    int32 frame_count;
+    int outidx, i, n_overflow, orig_n_overflow;
+    float32 const *orig_spch;
 
-int32
-fe_process_frame_float32(fe_t * fe, float32 const *spch, int32 nsamps, mfcc_t * fr_cep)
-{
-    if (!fe->is_float32) {
-        E_ERROR("Called fe_process_frame_float32 when -input_float32 is false\n");
-        return -1;
+    /* No output buffer, do nothing except set *inout_nframes */
+    if (buf_cep == NULL) {
+        if (*inout_nsamps + fe->num_overflow_samps < (size_t)fe->frame_size)
+            *inout_nframes = 0;
+        else
+            *inout_nframes = 1
+                + ((*inout_nsamps + fe->num_overflow_samps - fe->frame_size)
+                   / fe->frame_shift);
+        return 0;
     }
-        
-    fe_read_frame_float32(fe, spch, nsamps);
-    fe_write_frame(fe, fr_cep);
 
-    return 1;
-}
+    /* Are there not enough samples to make at least 1 frame? */
+    if (*inout_nsamps + fe->num_overflow_samps < (size_t)fe->frame_size) {
+        if (*inout_nsamps > 0) {
+            /* Append them to the overflow buffer. */
+            memcpy(fe->overflow_samps + fe->num_overflow_samps,
+                   *inout_spch, *inout_nsamps * (sizeof(**inout_spch)));
+            fe->num_overflow_samps += *inout_nsamps;
+            /* Update input-output pointers and counters. */
+            *inout_spch += *inout_nsamps;
+            *inout_nsamps = 0;
+        }
+        return 0;
+    }
 
-#define PROCESS_FRAMES_IMPL(SPCH_TYPE)                                  \
-int                                                                     \
-fe_process_frames_##SPCH_TYPE(fe_t *fe,                                 \
-                  SPCH_TYPE const **inout_spch,                         \
-                  size_t *inout_nsamps,                                 \
-                  mfcc_t **buf_cep,                                     \
-                  int32 *inout_nframes)                                 \
-{                                                                       \
-    int32 frame_count;                                                  \
-    int outidx, i, n_overflow, orig_n_overflow;                         \
-    SPCH_TYPE const *orig_spch;                                         \
-                                                                        \
-    if (fe->is_float32 != !strcmp(#SPCH_TYPE, "float32")) {             \
-        E_ERROR("Mismatch in input type for fe_process_frames_" #SPCH_TYPE "\n"); \
-        return -1;                                                      \
-    }                                                                   \
-    /* In the special case where there is no output buffer, return the  \
-     * maximum number of frames which would be generated. */            \
-    if (buf_cep == NULL) {                                              \
-        if (*inout_nsamps + fe->num_overflow_samps < (size_t)fe->frame_size) \
-            *inout_nframes = 0;                                         \
-        else                                                            \
-            *inout_nframes = 1                                          \
-                + ((*inout_nsamps + fe->num_overflow_samps - fe->frame_size) \
-                   / fe->frame_shift);                                  \
-        return *inout_nframes;                                          \
-    }                                                                   \
-                                                                        \
-    /* Are there not enough samples to make at least 1 frame? */        \
-    if (*inout_nsamps + fe->num_overflow_samps < (size_t)fe->frame_size) { \
-        if (*inout_nsamps > 0) {                                        \
-            /* Append them to the overflow buffer. */                   \
-            memcpy(fe->overflow_samps.s_##SPCH_TYPE + fe->num_overflow_samps, \
-                   *inout_spch, *inout_nsamps * (sizeof(**inout_spch))); \
-            fe->num_overflow_samps += *inout_nsamps;                    \
-            /* Update input-output pointers and counters. */            \
-            *inout_spch += *inout_nsamps;                               \
-            *inout_nsamps = 0;                                          \
-        }                                                               \
-        /* We produced no frames of output, sorry! */                   \
-        *inout_nframes = 0;                                             \
-        return 0;                                                       \
-    }                                                                   \
-                                                                        \
-    /* Can't write a frame?  Then do nothing! */                        \
-    if (*inout_nframes < 1) {                                           \
-        *inout_nframes = 0;                                             \
-        return 0;                                                       \
-    }                                                                   \
-                                                                        \
-    /* Keep track of the original start of the buffer. */               \
-    orig_spch = *inout_spch;                                            \
-    orig_n_overflow = fe->num_overflow_samps;                           \
-    /* How many frames will we be able to get? */                       \
-    frame_count = 1                                                     \
-        + ((*inout_nsamps + fe->num_overflow_samps - fe->frame_size)    \
-           / fe->frame_shift);                                          \
-    /* Limit it to the number of output frames available. */            \
-    if (frame_count > *inout_nframes)                                   \
-        frame_count = *inout_nframes;                                   \
-    /* Index of output frame. */                                        \
-    outidx = 0;                                                         \
-                                                                        \
-    /* Start processing, taking care of any incoming overflow. */       \
-    if (fe->num_overflow_samps) {                                       \
-        int offset = fe->frame_size - fe->num_overflow_samps;           \
-                                                                        \
-        /* Append start of spch to overflow samples to make a full frame. */ \
-        memcpy(fe->overflow_samps.s_##SPCH_TYPE + fe->num_overflow_samps, \
-               *inout_spch, offset * sizeof(**inout_spch));             \
-        fe_read_frame_##SPCH_TYPE(fe, fe->overflow_samps.s_##SPCH_TYPE, fe->frame_size); \
-        assert(outidx < frame_count);                                   \
-        fe_write_frame(fe, buf_cep[outidx]);                            \
-        outidx++;                                                       \
-        /* Update input-output pointers and counters. */                \
-        *inout_spch += offset;                                          \
-        *inout_nsamps -= offset;                                        \
-        fe->num_overflow_samps -= fe->frame_shift;                      \
-    }                                                                   \
-    else {                                                              \
-        fe_read_frame_##SPCH_TYPE(fe, *inout_spch, fe->frame_size);     \
-        assert(outidx < frame_count);                                   \
-        fe_write_frame(fe, buf_cep[outidx]);                            \
-        outidx++;                                                       \
-        /* Update input-output pointers and counters. */                \
-        *inout_spch += fe->frame_size;                                  \
-        *inout_nsamps -= fe->frame_size;                                \
-    }                                                                   \
-                                                                        \
-    /* Process all remaining frames. */                                 \
-    for (i = 1; i < frame_count; ++i) {                                 \
-        assert(*inout_nsamps >= (size_t)fe->frame_shift);               \
-                                                                        \
-        fe_shift_frame_##SPCH_TYPE(fe, *inout_spch, fe->frame_shift);   \
-        assert(outidx < frame_count);                                   \
-        fe_write_frame(fe, buf_cep[outidx]);                            \
-        outidx++;                                                       \
-        /* Update input-output pointers and counters. */                \
-        *inout_spch += fe->frame_shift;                                 \
-        *inout_nsamps -= fe->frame_shift;                               \
-        /* Amount of data behind the original input which is still needed. */ \
-        if (fe->num_overflow_samps > 0)                                 \
-            fe->num_overflow_samps -= fe->frame_shift;                  \
-    }                                                                   \
-                                                                        \
-    /* How many relevant overflow samples are there left? */            \
-    if (fe->num_overflow_samps <= 0) {                                  \
-        /* Maximum number of overflow samples past *inout_spch to save. */ \
-        n_overflow = *inout_nsamps;                                     \
-        if (n_overflow > fe->frame_shift)                               \
-            n_overflow = fe->frame_shift;                               \
-        fe->num_overflow_samps = fe->frame_size - fe->frame_shift;      \
-        /* Make sure this isn't an illegal read! */                     \
-        if (fe->num_overflow_samps > *inout_spch - orig_spch)           \
-            fe->num_overflow_samps = *inout_spch - orig_spch;           \
-        fe->num_overflow_samps += n_overflow;                           \
-        if (fe->num_overflow_samps > 0) {                               \
-            memcpy(fe->overflow_samps.s_##SPCH_TYPE,                     \
-                   *inout_spch - (fe->frame_size - fe->frame_shift),    \
-                   fe->num_overflow_samps * sizeof(**inout_spch));      \
-            /* Update the input pointer to cover this stuff. */         \
-            *inout_spch += n_overflow;                                  \
-            *inout_nsamps -= n_overflow;                                \
-        }                                                               \
-    }                                                                   \
-    else {                                                              \
-        /* There is still some relevant data left in the overflow buffer. */ \
-        /* Shift existing data to the beginning. */                     \
-        memmove(fe->overflow_samps.s_##SPCH_TYPE,                        \
-                fe->overflow_samps.s_##SPCH_TYPE + orig_n_overflow - fe->num_overflow_samps, \
-                fe->num_overflow_samps * sizeof(*fe->overflow_samps.s_##SPCH_TYPE)); \
-        /* Copy in whatever we had in the original speech buffer. */    \
-        n_overflow = *inout_spch - orig_spch + *inout_nsamps;           \
-        if (n_overflow > fe->frame_size - fe->num_overflow_samps)       \
-            n_overflow = fe->frame_size - fe->num_overflow_samps;       \
-        memcpy(fe->overflow_samps.s_##SPCH_TYPE + fe->num_overflow_samps, \
-               orig_spch, n_overflow * sizeof(*orig_spch));             \
-        fe->num_overflow_samps += n_overflow;                           \
-        /* Advance the input pointers. */                               \
-        if (n_overflow > *inout_spch - orig_spch) {                     \
-            n_overflow -= (*inout_spch - orig_spch);                    \
-            *inout_spch += n_overflow;                                  \
-            *inout_nsamps -= n_overflow;                                \
-        }                                                               \
-    }                                                                   \
-                                                                        \
-    /* Finally update the frame counter with the number of frames we procesed. */ \
-    *inout_nframes = outidx; /* FIXME: Not sure why I wrote it this way... */ \
-    return 0;                                                           \
+    /* No frames to write, nothing to do. */
+    if (*inout_nframes < 1)
+        return 0;
+
+    /* Keep track of the original start of the buffer. */
+    orig_spch = *inout_spch;
+    orig_n_overflow = fe->num_overflow_samps;
+    /* How many frames will we be able to get? */
+    frame_count = 1
+        + ((*inout_nsamps + fe->num_overflow_samps - fe->frame_size)
+           / fe->frame_shift);
+    /* Limit it to the number of output frames available. */
+    if (frame_count > *inout_nframes)
+        frame_count = *inout_nframes;
+    /* Index of output frame. */
+    outidx = 0;
+
+    /* Start processing, taking care of any incoming overflow. */
+    if (fe->num_overflow_samps) {
+        int offset = fe->frame_size - fe->num_overflow_samps;
+
+        /* Append start of spch to overflow samples to make a full frame. */
+        memcpy(fe->overflow_samps + fe->num_overflow_samps,
+               *inout_spch, offset * sizeof(**inout_spch));
+        fe_read_frame_float32(fe, fe->overflow_samps, fe->frame_size);
+        assert(outidx < frame_count);
+        fe_write_frame(fe, buf_cep[outidx]);
+        outidx++;
+        /* Update input-output pointers and counters. */
+        *inout_spch += offset;
+        *inout_nsamps -= offset;
+        fe->num_overflow_samps -= fe->frame_shift;
+    }
+    else {
+        fe_read_frame_float32(fe, *inout_spch, fe->frame_size);
+        assert(outidx < frame_count);
+        fe_write_frame(fe, buf_cep[outidx]);
+        outidx++;
+        /* Update input-output pointers and counters. */
+        *inout_spch += fe->frame_size;
+        *inout_nsamps -= fe->frame_size;
+    }
+
+    /* Process all remaining frames. */
+    for (i = 1; i < frame_count; ++i) {
+        assert(*inout_nsamps >= (size_t)fe->frame_shift);
+
+        fe_shift_frame_float32(fe, *inout_spch, fe->frame_shift);
+        assert(outidx < frame_count);
+        fe_write_frame(fe, buf_cep[outidx]);
+        outidx++;
+        /* Update input-output pointers and counters. */
+        *inout_spch += fe->frame_shift;
+        *inout_nsamps -= fe->frame_shift;
+        /* Amount of data behind the original input which is still needed. */
+        if (fe->num_overflow_samps > 0)
+            fe->num_overflow_samps -= fe->frame_shift;
+    }
+
+    /* How many relevant overflow samples are there left? */
+    if (fe->num_overflow_samps <= 0) {
+        /* Maximum number of overflow samples past *inout_spch to save. */
+        n_overflow = *inout_nsamps;
+        if (n_overflow > fe->frame_shift)
+            n_overflow = fe->frame_shift;
+        fe->num_overflow_samps = fe->frame_size - fe->frame_shift;
+        /* Make sure this isn't an illegal read! */
+        if (fe->num_overflow_samps > *inout_spch - orig_spch)
+            fe->num_overflow_samps = *inout_spch - orig_spch;
+        fe->num_overflow_samps += n_overflow;
+        if (fe->num_overflow_samps > 0) {
+            memcpy(fe->overflow_samps,
+                   *inout_spch - (fe->frame_size - fe->frame_shift),
+                   fe->num_overflow_samps * sizeof(**inout_spch));
+            /* Update the input pointer to cover this stuff. */
+            *inout_spch += n_overflow;
+            *inout_nsamps -= n_overflow;
+        }
+    }
+    else {
+        /* There is still some relevant data left in the overflow buffer. */
+        /* Shift existing data to the beginning. */
+        memmove(fe->overflow_samps,
+                fe->overflow_samps + orig_n_overflow - fe->num_overflow_samps,
+                fe->num_overflow_samps * sizeof(*fe->overflow_samps));
+        /* Copy in whatever we had in the original speech buffer. */
+        n_overflow = *inout_spch - orig_spch + *inout_nsamps;
+        if (n_overflow > fe->frame_size - fe->num_overflow_samps)
+            n_overflow = fe->frame_size - fe->num_overflow_samps;
+        memcpy(fe->overflow_samps + fe->num_overflow_samps,
+               orig_spch, n_overflow * sizeof(*orig_spch));
+        fe->num_overflow_samps += n_overflow;
+        /* Advance the input pointers. */
+        if (n_overflow > *inout_spch - orig_spch) {
+            n_overflow -= (*inout_spch - orig_spch);
+            *inout_spch += n_overflow;
+            *inout_nsamps -= n_overflow;
+        }
+    }
+
+    /* Finally update the frame counter using the number of frames we
+     * procesed. */
+    *inout_nframes -= outidx;
+    return outidx;
 }
-PROCESS_FRAMES_IMPL(int16)
-PROCESS_FRAMES_IMPL(float32)
 
 int
-fe_process_frames(fe_t *fe,
+fe_process_int16(fe_t *fe,
+                 int16 const **inout_spch,
+                 size_t *inout_nsamps,
+                 mfcc_t **buf_cep,
+                 int32 *inout_nframes)
+{
+    int32 frame_count;
+    int outidx, i, n_overflow, orig_n_overflow;
+    int16 const *orig_spch;
+
+    /* No output buffer, do nothing except set *inout_nframes */
+    if (buf_cep == NULL) {
+        if (*inout_nsamps + fe->num_overflow_samps < (size_t)fe->frame_size)
+            *inout_nframes = 0;
+        else
+            *inout_nframes = 1
+                + ((*inout_nsamps + fe->num_overflow_samps - fe->frame_size)
+                   / fe->frame_shift);
+        return 0;
+    }
+
+    /* Are there not enough samples to make at least 1 frame? */
+    if (*inout_nsamps + fe->num_overflow_samps < (size_t)fe->frame_size) {
+        if (*inout_nsamps > 0) {
+            /* Append them to the overflow buffer. */
+            size_t i;
+            for (i = 0; i < *inout_nsamps; ++i)
+                fe->overflow_samps[fe->num_overflow_samps + i] = (*inout_spch)[i];
+            fe->num_overflow_samps += *inout_nsamps;
+            /* Update input-output pointers and counters. */
+            *inout_spch += *inout_nsamps;
+            *inout_nsamps = 0;
+        }
+        return 0;
+    }
+
+    /* No frames to write, nothing to do. */
+    if (*inout_nframes < 1)
+        return 0;
+
+    /* Keep track of the original start of the buffer. */
+    orig_spch = *inout_spch;
+    orig_n_overflow = fe->num_overflow_samps;
+    /* How many frames will we be able to get? */
+    frame_count = 1
+        + ((*inout_nsamps + fe->num_overflow_samps - fe->frame_size)
+           / fe->frame_shift);
+    /* Limit it to the number of output frames available. */
+    if (frame_count > *inout_nframes)
+        frame_count = *inout_nframes;
+    /* Index of output frame. */
+    outidx = 0;
+
+    /* Start processing, taking care of any incoming overflow. */
+    if (fe->num_overflow_samps) {
+        int offset = fe->frame_size - fe->num_overflow_samps;
+
+        /* Append start of spch to overflow samples to make a full
+         * frame, making sure to pre-scale it. */
+        int i;
+        for (i = 0; i < offset; ++i)
+            fe->overflow_samps[fe->num_overflow_samps + i]
+                = (float32)(*inout_spch)[i] / FLOAT32_SCALE;
+        fe_read_frame_float32(fe, fe->overflow_samps, fe->frame_size);
+        assert(outidx < frame_count);
+        fe_write_frame(fe, buf_cep[outidx]);
+        outidx++;
+        /* Update input-output pointers and counters. */
+        *inout_spch += offset;
+        *inout_nsamps -= offset;
+        fe->num_overflow_samps -= fe->frame_shift;
+    }
+    else {
+        fe_read_frame_int16(fe, *inout_spch, fe->frame_size);
+        assert(outidx < frame_count);
+        fe_write_frame(fe, buf_cep[outidx]);
+        outidx++;
+        /* Update input-output pointers and counters. */
+        *inout_spch += fe->frame_size;
+        *inout_nsamps -= fe->frame_size;
+    }
+    E_INFO("after first frame pos %d remaining %d\n",
+           *inout_spch - orig_spch, *inout_nsamps);
+
+    /* Process all remaining frames. */
+    for (i = 1; i < frame_count; ++i) {
+        assert(*inout_nsamps >= (size_t)fe->frame_shift);
+
+        fe_shift_frame_int16(fe, *inout_spch, fe->frame_shift);
+        assert(outidx < frame_count);
+        fe_write_frame(fe, buf_cep[outidx]);
+        outidx++;
+        /* Update input-output pointers and counters. */
+        *inout_spch += fe->frame_shift;
+        *inout_nsamps -= fe->frame_shift;
+        /* Amount of data behind the original input which is still needed. */
+        if (fe->num_overflow_samps > 0)
+            fe->num_overflow_samps -= fe->frame_shift;
+        E_INFO("after frame %d pos %d remaining %d\n",
+               i, *inout_spch - orig_spch, *inout_nsamps);
+        E_INFO("remaining %d overflow samples\n",
+               fe->num_overflow_samps);
+    }
+    E_INFO("remaining %d overflow samples\n",
+           fe->num_overflow_samps);
+    E_INFO("remaining %d samples\n",
+           *inout_nsamps);
+
+    /* If there are remaining samples, create an extra frame in
+     * fe->overflow_samps, starting from the next input frame, with as
+     * much data as possible. */
+    if (fe->num_overflow_samps <= 0) {
+        /* There were no overflow samples to start with (FIXME: WHY
+         * DOES THIS MATTER?! */
+        /* Amount of data past *inout_spch to copy */
+        n_overflow = fe->frame_shift;
+        if (n_overflow > *inout_nsamps)
+            n_overflow = *inout_nsamps;
+        /* Size of constructed overflow frame */
+        fe->num_overflow_samps = (fe->frame_size - fe->frame_shift
+                                  + n_overflow);
+        assert(*inout_spch - orig_spch
+               > (fe->frame_size - fe->frame_shift));
+        if (fe->num_overflow_samps > 0) {
+            const int16 *inptr = *inout_spch - (fe->frame_size
+                                                - fe->frame_shift);
+            int i;
+            E_INFO("Copying %d samples from %d\n",
+                   fe->num_overflow_samps, inptr - orig_spch);
+            for (i = 0; i < fe->num_overflow_samps; ++i) {
+                /* Make sure to scale it! */
+                fe->overflow_samps[i]
+                    = (float32)inptr[i] / FLOAT32_SCALE;
+                E_INFOCONT("%.0f ", fe->overflow_samps[i]);
+            }
+            E_INFOCONT("\n");
+            /* Update the input pointer to cover this stuff. */
+            *inout_spch += n_overflow;
+            *inout_nsamps -= n_overflow;
+        }
+    }
+    else {
+        /* There is still some relevant data left in the overflow
+         * buffer. */
+        /* Shift existing data to the beginning (already scaled). */
+        memmove(fe->overflow_samps,
+                fe->overflow_samps + orig_n_overflow - fe->num_overflow_samps,
+                fe->num_overflow_samps * sizeof(*fe->overflow_samps));
+        /* Copy in whatever we had in the original speech buffer. */
+        n_overflow = *inout_spch - orig_spch + *inout_nsamps;
+        if (n_overflow > fe->frame_size - fe->num_overflow_samps)
+            n_overflow = fe->frame_size - fe->num_overflow_samps;
+        int i;
+        for (i = 0; i < n_overflow; ++i)
+            fe->overflow_samps[fe->num_overflow_samps + i] = orig_spch[i];
+        fe->num_overflow_samps += n_overflow;
+        /* Advance the input pointers. */
+        if (n_overflow > *inout_spch - orig_spch) {
+            n_overflow -= (*inout_spch - orig_spch);
+            *inout_spch += n_overflow;
+            *inout_nsamps -= n_overflow;
+        }
+    }
+
+    /* Finally update the frame counter using the number of frames we
+     * procesed. */
+    *inout_nframes -= outidx;
+    return outidx;
+}
+
+int
+fe_process(fe_t *fe,
                   int16 const **inout_spch,
                   size_t *inout_nsamps,
                   mfcc_t **buf_cep,
                   int32 *inout_nframes)
 {
-    return fe_process_frames_int16(fe, inout_spch, inout_nsamps, buf_cep, inout_nframes);
+    return fe_process_int16(fe, inout_spch, inout_nsamps,
+                            buf_cep, inout_nframes);
 }
 
 int
-fe_process_utt(fe_t * fe, int16 const * spch, size_t nsamps,
-               mfcc_t *** cep_block, int32 * nframes)
+fe_end_utt(fe_t *fe, mfcc_t *cepvector, int32 *nframes)
 {
-    mfcc_t **cep;
-    int rv;
-
-    /* Figure out how many frames we will need. */
-    fe_process_frames_int16(fe, NULL, &nsamps, NULL, nframes);
-    /* Create the output buffer (it has to exist, even if there are no output frames). */
-    if (*nframes)
-        cep = (mfcc_t **)ckd_calloc_2d(*nframes, fe->feature_dimension, sizeof(**cep));
-    else
-        cep = (mfcc_t **)ckd_calloc_2d(1, fe->feature_dimension, sizeof(**cep));
-    /* Now just call fe_process_frames() with the allocated buffer. */
-    rv = fe_process_frames_int16(fe, &spch, &nsamps, cep, nframes);
-    *cep_block = cep;
-
-    return rv;
-}
-
-int32
-fe_end_utt(fe_t * fe, mfcc_t * cepvector, int32 * nframes)
-{
-    /* Process any remaining data. */
-    if (fe->num_overflow_samps > 0) {
-        if (fe->is_float32)
-            fe_read_frame_float32(fe, fe->overflow_samps.s_float32,
-                                  fe->num_overflow_samps);
-        else
-            fe_read_frame_int16(fe, fe->overflow_samps.s_int16,
-                                fe->num_overflow_samps);
+    int nfr = 0;
+    
+    /* Process any remaining data if possible. */
+    if (cepvector && *nframes > 0 && fe->num_overflow_samps > 0) {
+        E_INFO("end_utt with %d overflow samples\n",
+               fe->num_overflow_samps);
+        fe_read_frame_float32(fe, fe->overflow_samps,
+                              fe->num_overflow_samps);
         fe_write_frame(fe, cepvector);
-        *nframes = 1;
-    }
-    else {
-        *nframes = 0;
+        nfr = 1;
+        *nframes -= nfr;
     }
 
     /* reset overflow buffers... */
     fe->num_overflow_samps = 0;
 
-    return 0;
+    return nfr;
 }
 
 fe_t *
@@ -601,7 +709,7 @@ fe_free(fe_t * fe)
     /* kill FE instance - free everything... */
     if (fe->mel_fb) {
         if (fe->mel_fb->mel_cosine)
-            fe_free_2d((void *) fe->mel_fb->mel_cosine);
+            ckd_free_2d((void *) fe->mel_fb->mel_cosine);
         ckd_free(fe->mel_fb->lifter);
         ckd_free(fe->mel_fb->spec_start);
         ckd_free(fe->mel_fb->filt_start);
@@ -609,13 +717,13 @@ fe_free(fe_t * fe)
         ckd_free(fe->mel_fb->filt_coeffs);
         ckd_free(fe->mel_fb);
     }
-    ckd_free(fe->spch.s_float32);
+    ckd_free(fe->spch);
     ckd_free(fe->frame);
     ckd_free(fe->ccc);
     ckd_free(fe->sss);
     ckd_free(fe->spec);
     ckd_free(fe->mfspec);
-    ckd_free(fe->overflow_samps.s_float32);
+    ckd_free(fe->overflow_samps);
     ckd_free(fe->hamming_window);
     if (fe->noise_stats)
         fe_free_noisestats(fe->noise_stats);

--- a/src/fe_interface.c
+++ b/src/fe_interface.c
@@ -386,6 +386,10 @@ overflow_append(fe_t *fe,
                 SWAP_INT16(&sample);
             fe->overflow_samps[fe->num_overflow_samps + i]
                 = (float32)sample / FLOAT32_SCALE;
+            if (fe->swap)
+                SWAP_FLOAT32(fe->overflow_samps
+                             + fe->num_overflow_samps
+                             + i);
         }
         /* Update input-output pointers and counters. */
         *spch += *inout_nsamps;
@@ -421,6 +425,10 @@ read_overflow_frame(fe_t *fe,
                 SWAP_INT16(&sample);
             fe->overflow_samps[fe->num_overflow_samps + i]
                 = (float32)sample / FLOAT32_SCALE;
+            if (fe->swap)
+                SWAP_FLOAT32(fe->overflow_samps
+                             + fe->num_overflow_samps
+                             + i);
         }
         *spch += offset;
         *inout_nsamps -= offset;
@@ -458,6 +466,9 @@ create_overflow_frame(fe_t *fe,
                 /* Make sure to scale it! */
                 fe->overflow_samps[i]
                     = (float32)inptr[i] / FLOAT32_SCALE;
+                /* And swap it back (overflow_samps is input-endian) */
+                if (fe->swap)
+                    SWAP_FLOAT32(fe->overflow_samps + i);
             }
             /* Update the input pointer to cover this stuff. */
             *spch += n_overflow;
@@ -503,6 +514,10 @@ append_overflow_frame(fe_t *fe,
                 SWAP_INT16(&sample);
             fe->overflow_samps[fe->num_overflow_samps + i]
                 = sample / FLOAT32_SCALE;
+            if (fe->swap)
+                SWAP_FLOAT32(fe->overflow_samps
+                             + fe->num_overflow_samps
+                             + i);
         }
         fe->num_overflow_samps += n_overflow;
         /* Advance the input pointers. */

--- a/src/fe_sigproc.c
+++ b/src/fe_sigproc.c
@@ -371,14 +371,22 @@ fe_read_frame_float32(fe_t * fe, float32 const *in, int32 len)
         len = fe->frame_size;
 
     /* Scale and dither if necessary. */
-    if (fe->dither)
-        for (i = 0; i < len; ++i)
+    if (fe->dither) {
+        for (i = 0; i < len; ++i) {
             fe->spch[i] =
                 (in[i] * FLOAT32_SCALE
                  + ((!(s3_rand_int31() % 4)) ? FLOAT32_DITHER : 0.0));
-    else
-        for (i = 0; i < len; ++i)
+            if (fe->swap)
+                SWAP_FLOAT32(fe->spch + i);
+        }
+    }
+    else {
+        for (i = 0; i < len; ++i) {
             fe->spch[i] = in[i] * FLOAT32_SCALE;
+            if (fe->swap)
+                SWAP_FLOAT32(fe->spch + i);
+        }
+    }
 
     return fe_spch_to_frame(fe, len);
 }
@@ -429,15 +437,29 @@ fe_shift_frame_float32(fe_t * fe, float32 const *in, int32 len)
     /* Shift data into the raw speech buffer. */
     memmove(fe->spch, fe->spch + fe->frame_shift,
             offset * sizeof(*fe->spch));
+    if (fe->swap) {
+        for (i = 0; i < offset; ++i) {
+            if (fe->swap)
+                SWAP_FLOAT32(fe->spch + i);
+        }
+    }
     /* Scale and dither if necessary. */
-    if (fe->dither)
-        for (i = 0; i < len; ++i)
+    if (fe->dither) {
+        for (i = 0; i < len; ++i){
             fe->spch[i + offset] =
                 (in[i] * FLOAT32_SCALE
                  + ((!(s3_rand_int31() % 4)) ? FLOAT32_DITHER : 0.0));
-    else
-        for (i = 0; i < len; ++i)
+            if (fe->swap)
+                SWAP_FLOAT32(fe->spch + i + offset);
+        }
+    }
+    else {
+        for (i = 0; i < len; ++i) {
             fe->spch[i + offset] = in[i] * FLOAT32_SCALE;
+            if (fe->swap)
+                SWAP_FLOAT32(fe->spch + i + offset);
+        }
+    }
 
     fe_spch_to_frame(fe, offset + len);
     return len;

--- a/src/fe_sigproc.c
+++ b/src/fe_sigproc.c
@@ -308,12 +308,6 @@ fe_hamming_window(frame_t * in, window_t * window, int32 in_len,
 static int
 fe_spch_to_frame(fe_t * fe, int len)
 {
-    E_INFO("fe_spch_to_frame(%d): ", len);
-    int i;
-    for (i = 0; i < len; ++i) {
-        E_INFOCONT("%.0f ", fe->spch[i]);
-    }
-    E_INFOCONT("\n");
     /* Copy to the frame buffer. */
     if (fe->pre_emphasis_alpha != 0.0) {
         fe_pre_emphasis(fe->spch, fe->frame, len,

--- a/tests/test_acmod.c
+++ b/tests/test_acmod.c
@@ -160,7 +160,7 @@ main(int argc, char *argv[])
     bptr = buf;
     nfr = frame_counter;
     fe_process(acmod->fe, &bptr, &nsamps, cepbuf, &nfr);
-    fe_end(acmod->fe, cepbuf[frame_counter-1], &nfr);
+    fe_end(acmod->fe, cepbuf + frame_counter - 1, &nfr);
 
     E_INFO("Incremental(MFCC):\n");
     cmn_live_set(acmod->fcb->cmn_struct, cmninit);
@@ -211,7 +211,7 @@ main(int argc, char *argv[])
     bptr = buf;
     nfr = frame_counter;
     fe_process(acmod->fe, &bptr, &nsamps, cepbuf, &nfr);
-    fe_end(acmod->fe, cepbuf[frame_counter-1], &nfr);
+    fe_end(acmod->fe, cepbuf + frame_counter - 1, &nfr);
 
     E_INFO("Whole utterance (MFCC):\n");
     cmn_live_set(acmod->fcb->cmn_struct, cmninit);

--- a/tests/test_acmod.c
+++ b/tests/test_acmod.c
@@ -159,7 +159,7 @@ main(int argc, char *argv[])
     nsamps = ftell(rawfh) / sizeof(*buf);
     bptr = buf;
     nfr = frame_counter;
-    fe_process(acmod->fe, &bptr, &nsamps, cepbuf, &nfr);
+    fe_process_int16(acmod->fe, &bptr, &nsamps, cepbuf, &nfr);
     fe_end(acmod->fe, cepbuf + frame_counter - 1, &nfr);
 
     E_INFO("Incremental(MFCC):\n");
@@ -210,7 +210,7 @@ main(int argc, char *argv[])
     nsamps = ftell(rawfh) / sizeof(*buf);
     bptr = buf;
     nfr = frame_counter;
-    fe_process(acmod->fe, &bptr, &nsamps, cepbuf, &nfr);
+    fe_process_int16(acmod->fe, &bptr, &nsamps, cepbuf, &nfr);
     fe_end(acmod->fe, cepbuf + frame_counter - 1, &nfr);
 
     E_INFO("Whole utterance (MFCC):\n");

--- a/tests/test_acmod.c
+++ b/tests/test_acmod.c
@@ -159,7 +159,7 @@ main(int argc, char *argv[])
     nsamps = ftell(rawfh) / sizeof(*buf);
     bptr = buf;
     nfr = frame_counter;
-    fe_process_frames(acmod->fe, &bptr, &nsamps, cepbuf, &nfr);
+    fe_process(acmod->fe, &bptr, &nsamps, cepbuf, &nfr);
     fe_end_utt(acmod->fe, cepbuf[frame_counter-1], &nfr);
 
     E_INFO("Incremental(MFCC):\n");
@@ -210,7 +210,7 @@ main(int argc, char *argv[])
     nsamps = ftell(rawfh) / sizeof(*buf);
     bptr = buf;
     nfr = frame_counter;
-    fe_process_frames(acmod->fe, &bptr, &nsamps, cepbuf, &nfr);
+    fe_process(acmod->fe, &bptr, &nsamps, cepbuf, &nfr);
     fe_end_utt(acmod->fe, cepbuf[frame_counter-1], &nfr);
 
     E_INFO("Whole utterance (MFCC):\n");

--- a/tests/test_acmod.c
+++ b/tests/test_acmod.c
@@ -155,12 +155,12 @@ main(int argc, char *argv[])
     cepbuf = ckd_calloc_2d(frame_counter,
                    fe_get_output_size(acmod->fe),
                    sizeof(**cepbuf));
-    fe_start_utt(acmod->fe);
+    fe_start(acmod->fe);
     nsamps = ftell(rawfh) / sizeof(*buf);
     bptr = buf;
     nfr = frame_counter;
     fe_process(acmod->fe, &bptr, &nsamps, cepbuf, &nfr);
-    fe_end_utt(acmod->fe, cepbuf[frame_counter-1], &nfr);
+    fe_end(acmod->fe, cepbuf[frame_counter-1], &nfr);
 
     E_INFO("Incremental(MFCC):\n");
     cmn_live_set(acmod->fcb->cmn_struct, cmninit);
@@ -206,12 +206,12 @@ main(int argc, char *argv[])
 
     /* Note that we have to process the whole thing again because
      * !#@$@ s2mfc2feat modifies its argument (not for long) */
-    fe_start_utt(acmod->fe);
+    fe_start(acmod->fe);
     nsamps = ftell(rawfh) / sizeof(*buf);
     bptr = buf;
     nfr = frame_counter;
     fe_process(acmod->fe, &bptr, &nsamps, cepbuf, &nfr);
-    fe_end_utt(acmod->fe, cepbuf[frame_counter-1], &nfr);
+    fe_end(acmod->fe, cepbuf[frame_counter-1], &nfr);
 
     E_INFO("Whole utterance (MFCC):\n");
     cmn_live_set(acmod->fcb->cmn_struct, cmninit);

--- a/tests/test_fe.c
+++ b/tests/test_fe.c
@@ -147,7 +147,7 @@ create_frames(fe_t *fe, const int16 *data, size_t nsamp)
     TEST_EQUAL(inptr - data, 1024);
     TEST_EQUAL(nsamp, 0);
     /* Should get a frame here due to overflow samples. */
-    rv = fe_end(fe, cepbuf[4], &nfr);
+    rv = fe_end(fe, cepbuf + 4, &nfr);
     E_INFO("fe_end rv %d nfr %d\n", rv, nfr);
     TEST_EQUAL(rv, 1);
     TEST_EQUAL(nfr, 0);
@@ -178,7 +178,7 @@ create_full(fe_t *fe, const int16 *data, size_t nsamp)
     TEST_EQUAL(inptr - data, 1024);
     TEST_EQUAL(nsamp, 0);
     /* Should get a frame here due to overflow samples. */
-    rv = fe_end(fe, cepbuf[4], &nfr);
+    rv = fe_end(fe, cepbuf + 4, &nfr);
     E_INFO("fe_end rv %d nfr %d\n", rv, nfr);
     TEST_EQUAL(rv, 1);
     TEST_EQUAL(nfr, 0);
@@ -223,7 +223,7 @@ create_process_frames(fe_t *fe, const int16 *data, size_t nsamp)
 
     /* Should get a frame here due to overflow samples. */
     nfr = 1;
-    rv = fe_end(fe, cepbuf[4], &nfr);
+    rv = fe_end(fe, cepbuf + 4, &nfr);
     E_INFO("fe_end rv %d nfr %d\n", rv, nfr);
     TEST_EQUAL(rv, 1);
     TEST_EQUAL(nfr, 0);
@@ -266,7 +266,7 @@ create_fragments(fe_t *fe, const int16 *data, size_t nsamp)
 
     /* Should get a frame here due to overflow samples. */
     nfr = 1;
-    rv = fe_end(fe, cepbuf[4], &nfr);
+    rv = fe_end(fe, cepbuf + 4, &nfr);
     E_INFO("fe_end rv %d nfr %d\n", rv, nfr);
     TEST_EQUAL(rv, 1);
 

--- a/tests/test_fe.c
+++ b/tests/test_fe.c
@@ -130,14 +130,12 @@ create_frames(fe_t *fe, const int16 *data, size_t nsamp)
     const int16 *inptr;
     int rv, nfr, ncep;
     
-    TEST_EQUAL(0, fe_start_utt(fe));
+    TEST_EQUAL(0, fe_start(fe));
     rv = fe_process(fe, NULL, &nsamp, NULL, &nfr);
     TEST_EQUAL(0, rv);
-    TEST_EQUAL(4, nfr);
+    TEST_EQUAL(5, nfr);
     ncep = fe_get_output_size(fe);
 
-    /* Allow an extra overflow frame. */
-    ++nfr;
     cepbuf = ckd_calloc_2d(nfr, ncep, sizeof(**cepbuf));
     inptr = data;
 
@@ -149,8 +147,8 @@ create_frames(fe_t *fe, const int16 *data, size_t nsamp)
     TEST_EQUAL(inptr - data, 1024);
     TEST_EQUAL(nsamp, 0);
     /* Should get a frame here due to overflow samples. */
-    rv = fe_end_utt(fe, cepbuf[4], &nfr);
-    E_INFO("fe_end_utt rv %d nfr %d\n", rv, nfr);
+    rv = fe_end(fe, cepbuf[4], &nfr);
+    E_INFO("fe_end rv %d nfr %d\n", rv, nfr);
     TEST_EQUAL(rv, 1);
     TEST_EQUAL(nfr, 0);
 
@@ -164,14 +162,12 @@ create_full(fe_t *fe, const int16 *data, size_t nsamp)
     const int16 *inptr;
     int rv, nfr, ncep;
     
-    TEST_EQUAL(0, fe_start_utt(fe));
+    TEST_EQUAL(0, fe_start(fe));
     rv = fe_process(fe, NULL, &nsamp, NULL, &nfr);
     TEST_EQUAL(0, rv);
-    TEST_EQUAL(4, nfr);
+    TEST_EQUAL(5, nfr);
     ncep = fe_get_output_size(fe);
 
-    /* Allow an extra overflow frame. */
-    ++nfr;
     cepbuf = ckd_calloc_2d(nfr, ncep, sizeof(**cepbuf));
     inptr = data;
     rv = fe_process(fe, &inptr, &nsamp, cepbuf, &nfr);
@@ -182,8 +178,8 @@ create_full(fe_t *fe, const int16 *data, size_t nsamp)
     TEST_EQUAL(inptr - data, 1024);
     TEST_EQUAL(nsamp, 0);
     /* Should get a frame here due to overflow samples. */
-    rv = fe_end_utt(fe, cepbuf[4], &nfr);
-    E_INFO("fe_end_utt rv %d nfr %d\n", rv, nfr);
+    rv = fe_end(fe, cepbuf[4], &nfr);
+    E_INFO("fe_end rv %d nfr %d\n", rv, nfr);
     TEST_EQUAL(rv, 1);
     TEST_EQUAL(nfr, 0);
 
@@ -198,14 +194,12 @@ create_process_frames(fe_t *fe, const int16 *data, size_t nsamp)
     int i, rv, nfr, ncep, frame_shift, frame_size;
     
     fe_get_input_size(fe, &frame_shift, &frame_size);
-    TEST_EQUAL(0, fe_start_utt(fe));
+    TEST_EQUAL(0, fe_start(fe));
     rv = fe_process(fe, NULL, &nsamp, NULL, &nfr);
     TEST_EQUAL(0, rv);
-    TEST_EQUAL(4, nfr);
+    TEST_EQUAL(5, nfr);
     ncep = fe_get_output_size(fe);
 
-    /* Allow an extra overflow frame. */
-    ++nfr;
     cepbuf = ckd_calloc_2d(nfr, ncep, sizeof(**cepbuf));
     inptr = data;
 
@@ -229,8 +223,8 @@ create_process_frames(fe_t *fe, const int16 *data, size_t nsamp)
 
     /* Should get a frame here due to overflow samples. */
     nfr = 1;
-    rv = fe_end_utt(fe, cepbuf[4], &nfr);
-    E_INFO("fe_end_utt rv %d nfr %d\n", rv, nfr);
+    rv = fe_end(fe, cepbuf[4], &nfr);
+    E_INFO("fe_end rv %d nfr %d\n", rv, nfr);
     TEST_EQUAL(rv, 1);
     TEST_EQUAL(nfr, 0);
 
@@ -250,14 +244,12 @@ create_fragments(fe_t *fe, const int16 *data, size_t nsamp)
     };
     
     fe_get_input_size(fe, &frame_shift, &frame_size);
-    TEST_EQUAL(0, fe_start_utt(fe));
+    TEST_EQUAL(0, fe_start(fe));
     rv = fe_process(fe, NULL, &nsamp, NULL, &nfr);
     TEST_EQUAL(0, rv);
-    TEST_EQUAL(4, nfr);
+    TEST_EQUAL(5, nfr);
     ncep = fe_get_output_size(fe);
 
-    /* Allow an extra overflow frame. */
-    ++nfr;
     cepptr = cepbuf = ckd_calloc_2d(nfr, ncep, sizeof(**cepbuf));
     inptr = data;
 
@@ -274,8 +266,8 @@ create_fragments(fe_t *fe, const int16 *data, size_t nsamp)
 
     /* Should get a frame here due to overflow samples. */
     nfr = 1;
-    rv = fe_end_utt(fe, cepbuf[4], &nfr);
-    E_INFO("fe_end_utt rv %d nfr %d\n", rv, nfr);
+    rv = fe_end(fe, cepbuf[4], &nfr);
+    E_INFO("fe_end rv %d nfr %d\n", rv, nfr);
     TEST_EQUAL(rv, 1);
 
     return cepbuf;
@@ -344,7 +336,7 @@ main(int argc, char *argv[])
     compare_cepstra(cepbuf, cepbuf1, 5, DEFAULT_NUM_CEPSTRA);
     ckd_free_2d(cepbuf1);
 
-    E_INFO("Creating features with individual frames\n");
+    E_INFO("Creating features with oddly sized fragments\n");
     cepbuf1 = create_fragments(fe, buf, 1024);
     compare_cepstra(cepbuf, cepbuf1, 5, DEFAULT_NUM_CEPSTRA);
     ckd_free_2d(cepbuf1);

--- a/tests/test_fe.c
+++ b/tests/test_fe.c
@@ -4,11 +4,250 @@
 #include <string.h>
 
 #include <soundswallower/fe.h>
+#include <soundswallower/fe_internal.h>
 #include <soundswallower/err.h>
 #include <soundswallower/cmd_ln.h>
 #include <soundswallower/ckd_alloc.h>
 
 #include "test_macros.h"
+
+/**
+ * Create a "reference" MFCC processing only whole frames
+ */
+mfcc_t **
+create_reference(fe_t *fe, int16 *data, size_t nsamp)
+{
+    int32 frame_shift, frame_size;
+    int nfr_full, nfr_output, ncep, i;
+    mfcc_t **cepbuf;
+
+    fe_get_input_size(fe, &frame_shift, &frame_size);
+    /* Number of full frames that can be extracted from the given
+     * number of samples. */
+    nfr_full = 1 + (nsamp - frame_size) / frame_shift;
+    E_INFO("1 + (%d samples - %d frame_size) / %d frame_shift = %d\n",
+           nsamp, frame_size, frame_shift, nfr_full);
+    /* Number that will be extracted overall. */
+    if ((size_t)(nfr_full - 1) * frame_shift + frame_size < nsamp) {
+        nfr_output = nfr_full + 1;
+        E_INFO("%d extra samples, nfr = %d\n",
+               nsamp - ((nfr_full - 1) * frame_shift + frame_size),
+               nfr_output);
+    }
+    else {
+        nfr_output = nfr_full;
+    }
+    ncep = fe_get_output_size(fe);
+    E_INFO("ncep = %d\n", ncep);
+    cepbuf = ckd_calloc_2d(nfr_output, ncep, sizeof(**cepbuf));
+
+    for (i = 0; i < nfr_full; ++i) {
+        E_INFO("frame %d from %d to %d\n",
+               i, i * frame_shift, i * frame_shift + frame_size);
+        fe_read_frame_int16(fe, data + (i * frame_shift), frame_size);
+        fe_write_frame(fe, cepbuf[i]);
+    }
+
+    /* Create the last frame explicitly to ensure no lossage. */
+    if (nfr_output > nfr_full) {
+        int last_frame_size = nsamp - nfr_full * frame_shift;
+        int16 *last_frame = ckd_calloc(last_frame_size,
+                                       sizeof(*last_frame));
+        E_INFO("frame %d from %d to %d (%d samples)\n",
+               nfr_full, nfr_full * frame_shift, nsamp,
+               last_frame_size);
+        memcpy(last_frame,
+               data + nfr_full * frame_shift,
+               last_frame_size * sizeof(*data));
+        fe_read_frame_int16(fe, last_frame, last_frame_size);
+        fe_write_frame(fe, cepbuf[nfr_full]);
+    }
+
+    for (i = 0; i < 5; ++i) {
+        int j;
+        E_INFO("%d: ", i);
+        for (j = 0; j < ncep; ++j) {
+            E_INFOCONT("%.2f ",
+                       MFCC2FLOAT(cepbuf[i][j]));
+        }
+        E_INFOCONT("\n");
+    }
+    return cepbuf;
+}
+
+/**
+ * Create MFCC using shift_frame
+ */
+mfcc_t **
+create_shifted(fe_t *fe, int16 *data, size_t nsamp)
+{
+    int32 frame_shift, frame_size;
+    int nfr_full, nfr_output, ncep, i;
+    mfcc_t **cepbuf;
+    int16 *inptr;
+
+    fe_get_input_size(fe, &frame_shift, &frame_size);
+    /* Number of full frames that can be extracted from the given
+     * number of samples. */
+    nfr_full = 1 + (nsamp - frame_size) / frame_shift;
+    /* Number that will be extracted overall. */
+    if ((size_t)(nfr_full - 1) * frame_shift + frame_size < nsamp)
+        nfr_output = nfr_full + 1;
+    else
+        nfr_output = nfr_full;
+    ncep = fe_get_output_size(fe);
+    cepbuf = ckd_calloc_2d(nfr_output, ncep, sizeof(**cepbuf));
+
+    inptr = data;
+    E_INFO("start inptr = %ld\n", inptr - data);
+    inptr += fe_read_frame_int16(fe, inptr, frame_size);
+    fe_write_frame(fe, cepbuf[0]);
+    E_INFO("after first frame = %ld\n", inptr - data);
+    for (i = 1; i < nfr_output; ++i) {
+        inptr += fe_shift_frame_int16(fe, inptr, data + nsamp - inptr);
+        fe_write_frame(fe, cepbuf[i]);
+        E_INFO("after frame %d = %ld\n", i, inptr - data);
+    }
+    TEST_EQUAL(inptr, data + nsamp);
+
+    for (i = 0; i < nfr_output; ++i) {
+        int j;
+        E_INFO("%d: ", i);
+        for (j = 0; j < ncep; ++j) {
+            E_INFOCONT("%.2f ",
+                       MFCC2FLOAT(cepbuf[i][j]));
+        }
+        E_INFOCONT("\n");
+    }
+    return cepbuf;
+}
+
+mfcc_t **
+create_frames(fe_t *fe, const int16 *data, size_t nsamp)
+{
+    mfcc_t **cepbuf;
+    const int16 *inptr;
+    int rv, nfr, ncep;
+    
+    TEST_EQUAL(0, fe_start_utt(fe));
+    rv = fe_process(fe, NULL, &nsamp, NULL, &nfr);
+    TEST_EQUAL(0, rv);
+    TEST_EQUAL(4, nfr);
+    ncep = fe_get_output_size(fe);
+
+    /* Allow an extra overflow frame. */
+    ++nfr;
+    cepbuf = ckd_calloc_2d(nfr, ncep, sizeof(**cepbuf));
+    inptr = data;
+
+    rv = fe_process(fe, &inptr, &nsamp, cepbuf, &nfr);
+    E_INFO("fe_process_frames produced %d frames, "
+           " %d samples remaining\n", rv, nsamp);
+    TEST_EQUAL(rv, 4);
+    TEST_EQUAL(nfr, 1);
+    TEST_EQUAL(inptr - data, 1024);
+    TEST_EQUAL(nsamp, 0);
+    /* Should get a frame here due to overflow samples. */
+    rv = fe_end_utt(fe, cepbuf[4], &nfr);
+    E_INFO("fe_end_utt rv %d nfr %d\n", rv, nfr);
+    TEST_EQUAL(rv, 1);
+    TEST_EQUAL(nfr, 0);
+
+    return cepbuf;
+}
+
+mfcc_t **
+create_full(fe_t *fe, const int16 *data, size_t nsamp)
+{
+    mfcc_t **cepbuf;
+    const int16 *inptr;
+    int rv, nfr, ncep;
+    
+    TEST_EQUAL(0, fe_start_utt(fe));
+    rv = fe_process(fe, NULL, &nsamp, NULL, &nfr);
+    TEST_EQUAL(0, rv);
+    TEST_EQUAL(4, nfr);
+    ncep = fe_get_output_size(fe);
+
+    /* Allow an extra overflow frame. */
+    ++nfr;
+    cepbuf = ckd_calloc_2d(nfr, ncep, sizeof(**cepbuf));
+    inptr = data;
+    rv = fe_process(fe, &inptr, &nsamp, cepbuf, &nfr);
+    E_INFO("fe_process_frames produced %d frames, "
+           " %d samples remaining\n", rv, nsamp);
+    TEST_EQUAL(rv, 4);
+    TEST_EQUAL(nfr, 1);
+    TEST_EQUAL(inptr - data, 1024);
+    TEST_EQUAL(nsamp, 0);
+    /* Should get a frame here due to overflow samples. */
+    rv = fe_end_utt(fe, cepbuf[4], &nfr);
+    E_INFO("fe_end_utt rv %d nfr %d\n", rv, nfr);
+    TEST_EQUAL(rv, 1);
+    TEST_EQUAL(nfr, 0);
+
+    return cepbuf;
+}
+
+mfcc_t **
+create_process_frames(fe_t *fe, const int16 *data, size_t nsamp)
+{
+    mfcc_t **cepbuf;
+    const int16 *inptr;
+    int i, rv, nfr, ncep, frame_shift, frame_size;
+    
+    fe_get_input_size(fe, &frame_shift, &frame_size);
+    TEST_EQUAL(0, fe_start_utt(fe));
+    rv = fe_process(fe, NULL, &nsamp, NULL, &nfr);
+    TEST_EQUAL(0, rv);
+    TEST_EQUAL(4, nfr);
+    ncep = fe_get_output_size(fe);
+
+    /* Allow an extra overflow frame. */
+    ++nfr;
+    cepbuf = ckd_calloc_2d(nfr, ncep, sizeof(**cepbuf));
+    inptr = data;
+
+    for (i = 0; i < 4; ++i) {
+        nfr = 1;
+        rv = fe_process(fe, &inptr, &nsamp, &cepbuf[i], &nfr);
+        E_INFO("frame %d updated inptr %ld remaining nsamp %ld "
+               "processed %d remaining nfr %d\n",
+               i, inptr - data, nsamp, rv, nfr);
+        TEST_EQUAL(rv, 1);
+        TEST_EQUAL(nfr, 0);
+        if (i < 3) {
+            TEST_EQUAL(inptr - data, frame_size + i * frame_shift);
+        }
+        else {
+            TEST_EQUAL(inptr - data, 1024);
+        }
+    }
+
+    /* Should get a frame here due to overflow samples. */
+    rv = fe_end_utt(fe, cepbuf[4], &nfr);
+    E_INFO("fe_end_utt rv %d nfr %d\n", rv, nfr);
+    TEST_EQUAL(rv, 1);
+    TEST_EQUAL(nfr, 0);
+
+    return cepbuf;
+}
+
+void
+compare_cepstra(mfcc_t **c1, mfcc_t **c2, int nfr, int ncep)
+{
+    int i, j;
+    for (i = 0; i < nfr; ++i) {
+        E_INFO("%d: ", i);
+        for (j = 0; j < ncep; ++j) {
+            E_INFOCONT("%.2f,%.2f ",
+                       MFCC2FLOAT(c1[i][j]),
+                       MFCC2FLOAT(c2[i][j]));
+            TEST_EQUAL_FLOAT(c1[i][j], c2[i][j]);
+        }
+        E_INFOCONT("\n");
+    }
+}
 
 int
 main(int argc, char *argv[])
@@ -23,8 +262,8 @@ main(int argc, char *argv[])
     int16 buf[1024];
     int16 const *inptr;
     int32 frame_shift, frame_size;
-    mfcc_t **cepbuf1, **cepbuf2, **cptr;
-    int32 nfr, i;
+    mfcc_t **cepbuf, **cepbuf1, **cepbuf2, **cptr;
+    int32 nfr, nvec, i;
     size_t nsamp;
 
     err_set_loglevel_str("INFO");
@@ -35,89 +274,35 @@ main(int argc, char *argv[])
 
     fe_get_input_size(fe, &frame_shift, &frame_size);
     TEST_EQUAL(frame_shift, DEFAULT_FRAME_SHIFT);
-    TEST_EQUAL(frame_size, (int)(DEFAULT_WINDOW_LENGTH*DEFAULT_SAMPLING_RATE));
+    TEST_EQUAL(frame_size, (int)(DEFAULT_WINDOW_LENGTH
+                                 * DEFAULT_SAMPLING_RATE));
 
 
     TEST_ASSERT(raw = fopen(TESTDATADIR "/goforward.raw", "rb"));
-
-    TEST_EQUAL(0, fe_start_utt(fe));
     TEST_EQUAL(1024, fread(buf, sizeof(int16), 1024, raw));
 
-    nsamp = 1024;
-    TEST_ASSERT(fe_process_frames(fe, NULL, &nsamp, NULL, &nfr) >= 0);
-    TEST_EQUAL(1024, nsamp);
-    TEST_EQUAL(4, nfr);
+    E_INFO("Creating reference features\n");
+    cepbuf = create_reference(fe, buf, 1024);
+ 
+    E_INFO("Creating features with frame_shift\n");
+    cepbuf1 = create_shifted(fe, buf, 1024);
+    compare_cepstra(cepbuf, cepbuf1, 5, DEFAULT_NUM_CEPSTRA);
+    ckd_free_2d(cepbuf1);
 
-    cepbuf1 = ckd_calloc_2d(5, DEFAULT_NUM_CEPSTRA, sizeof(**cepbuf1));
-    inptr = &buf[0];
-    nfr = 1;
+    E_INFO("Creating features with full buffer\n");
+    cepbuf1 = create_full(fe, buf, 1024);
+    compare_cepstra(cepbuf, cepbuf1, 5, DEFAULT_NUM_CEPSTRA);
+    ckd_free_2d(cepbuf1);
 
-    /* Process the data, one frame at a time. */
-    E_INFO("Testing one frame at a time (1024 samples)\n");
-    E_INFO("frame_size %d frame_shift %d\n", frame_size, frame_shift);
-    TEST_ASSERT(fe_process_frames(fe, &inptr, &nsamp, &cepbuf1[0], &nfr) >= 0);
-    E_INFO("updated inptr %ld remaining nsamp %ld processed nfr %d\n",
-	   inptr - buf, nsamp, nfr);
-    TEST_EQUAL(nfr, 1);
-    TEST_EQUAL(inptr - buf, frame_size + frame_shift);
+    E_INFO("Creating features with individual frames\n");
+    cepbuf1 = create_process_frames(fe, buf, 1024);
+    compare_cepstra(cepbuf, cepbuf1, 5, DEFAULT_NUM_CEPSTRA);
+    ckd_free_2d(cepbuf1);
 
-    nfr = 1;
-    TEST_ASSERT(fe_process_frames(fe, &inptr, &nsamp, &cepbuf1[1], &nfr) >= 0);
-    E_INFO("updated inptr %ld remaining nsamp %ld processed nfr %d\n",
-	   inptr - buf, nsamp, nfr);
-    TEST_EQUAL(nfr, 1);
-    TEST_EQUAL(inptr - buf, frame_size + 2 * frame_shift);
-    
-    nfr = 1;
-    TEST_ASSERT(fe_process_frames(fe, &inptr, &nsamp, &cepbuf1[2], &nfr) >= 0);
-    E_INFO("updated inptr %ld remaining nsamp %ld processed nfr %d\n",
-	   inptr - buf, nsamp, nfr);
-    TEST_EQUAL(nfr, 1);
-    TEST_EQUAL(inptr - buf, frame_size + 3 * frame_shift);
 
-    /* Should consume all the input at this point. */
-    nfr = 1;
-    TEST_ASSERT(fe_process_frames(fe, &inptr, &nsamp, &cepbuf1[3], &nfr) >= 0);
-    E_INFO("updated inptr %ld remaining nsamp %ld processed nfr %d\n",
-	   inptr - buf, nsamp, nfr);
-    TEST_EQUAL(nfr, 1);
-    TEST_EQUAL(inptr - buf, 1024);
-    TEST_EQUAL(nsamp, 0);
-
-    /* Should get a frame here due to overflow samples. */
-    TEST_ASSERT(fe_end_utt(fe, cepbuf1[4], &nfr) >= 0);
-    E_INFO("fe_end_utt nfr %d\n", nfr);
-    TEST_EQUAL(nfr, 1);
-
+#if 0
     /* Test that the output we get by processing one frame at a time
      * is exactly the same as what we get from doing them all at once. */
-    E_INFO("Testing all data at once (1024 samples)\n");
-    cepbuf2 = ckd_calloc_2d(5, DEFAULT_NUM_CEPSTRA, sizeof(**cepbuf2));
-    inptr = &buf[0];
-    nfr = 5;
-    nsamp = 1024;
-    TEST_EQUAL(0, fe_start_utt(fe));
-    TEST_ASSERT(fe_process_frames(fe, &inptr, &nsamp, cepbuf2, &nfr) >= 0);
-    E_INFO("fe_process_frames consumed nfr %d frames\n", nfr);
-    TEST_EQUAL(nfr, 4);
-    TEST_EQUAL(inptr - buf, 1024);
-    TEST_EQUAL(nsamp, 0);
-    /* And again, should get a frame here due to overflow samples. */
-    TEST_ASSERT(fe_end_utt(fe, cepbuf2[4], &nfr) >= 0);
-    E_INFO("fe_end_utt nfr %d\n", nfr);
-    TEST_EQUAL(nfr, 1);
-
-    /* output features stored in cepbuf should be the same */
-    for (nfr = 0; nfr < 5; ++nfr) {
-      E_INFO("%d: ", nfr);
-      for (i = 0; i < DEFAULT_NUM_CEPSTRA; ++i) {
-        E_INFOCONT("%.2f,%.2f ",
-		   MFCC2FLOAT(cepbuf1[nfr][i]),
-		   MFCC2FLOAT(cepbuf2[nfr][i]));
-        TEST_EQUAL_FLOAT(cepbuf1[nfr][i], cepbuf2[nfr][i]);
-      }
-      E_INFOCONT("\n");
-    }
     
     /* Now, also test to make sure that even if we feed data in
      * little tiny bits we can still make things work. */
@@ -175,58 +360,10 @@ main(int argc, char *argv[])
       }
       E_INFOCONT("\n");
     }
-
-    /* And now, finally, test fe_process_utt() */
-    E_INFO("Test fe_process_utt (apparently, it is deprecated)\n");
-    inptr = &buf[0];
-    i = 0;
-    TEST_EQUAL(0, fe_start_utt(fe));
-    TEST_ASSERT(fe_process_utt(fe, inptr, 256, &cptr, &nfr) >= 0);
-    E_INFO("i %d nfr %d\n", i, nfr);
-    if (nfr)
-        memcpy(cepbuf2[i], cptr[0], nfr * DEFAULT_NUM_CEPSTRA * sizeof(**cptr));
-    ckd_free_2d(cptr);
-    i += nfr;
-    inptr += 256;
-    TEST_ASSERT(fe_process_utt(fe, inptr, 256, &cptr, &nfr) >= 0);
-    E_INFO("i %d nfr %d\n", i, nfr);
-    if (nfr)
-        memcpy(cepbuf2[i], cptr[0], nfr * DEFAULT_NUM_CEPSTRA * sizeof(**cptr));
-    ckd_free_2d(cptr);
-    i += nfr;
-    inptr += 256;
-    TEST_ASSERT(fe_process_utt(fe, inptr, 256, &cptr, &nfr) >= 0);
-    E_INFO("i %d nfr %d\n", i, nfr);
-    if (nfr)
-        memcpy(cepbuf2[i], cptr[0], nfr * DEFAULT_NUM_CEPSTRA * sizeof(**cptr));
-    ckd_free_2d(cptr);
-    i += nfr;
-    inptr += 256;
-    TEST_ASSERT(fe_process_utt(fe, inptr, 256, &cptr, &nfr) >= 0);
-    E_INFO("i %d nfr %d\n", i, nfr);
-    if (nfr)
-        memcpy(cepbuf2[i], cptr[0], nfr * DEFAULT_NUM_CEPSTRA * sizeof(**cptr));
-    ckd_free_2d(cptr);
-    i += nfr;
-    inptr += 256;
-    TEST_ASSERT(fe_end_utt(fe, cepbuf2[i], &nfr) >= 0);
-    E_INFO("i %d nfr %d\n", i, nfr);
-    TEST_EQUAL(nfr, 1);
-
-    /* output features stored in cepbuf should be the same */
-    for (nfr = 0; nfr < 5; ++nfr) {
-      E_INFO("%d: ", nfr);
-      for (i = 0; i < DEFAULT_NUM_CEPSTRA; ++i) {
-        E_INFOCONT("%.2f,%.2f ",
-		   MFCC2FLOAT(cepbuf1[nfr][i]),
-		   MFCC2FLOAT(cepbuf2[nfr][i]));
-        TEST_EQUAL_FLOAT(cepbuf1[nfr][i], cepbuf2[nfr][i]);
-      }
-      E_INFOCONT("\n");
-    }
-
+    ckd_free_2d(cepbuf);
     ckd_free_2d(cepbuf1);
     ckd_free_2d(cepbuf2);
+#endif
     fclose(raw);
     fe_free(fe);
     cmd_ln_free_r(config);

--- a/tests/test_fe.c
+++ b/tests/test_fe.c
@@ -131,7 +131,7 @@ create_frames(fe_t *fe, const int16 *data, size_t nsamp)
     int rv, nfr, ncep;
     
     TEST_EQUAL(0, fe_start(fe));
-    rv = fe_process(fe, NULL, &nsamp, NULL, &nfr);
+    rv = fe_process_int16(fe, NULL, &nsamp, NULL, &nfr);
     TEST_EQUAL(0, rv);
     TEST_EQUAL(5, nfr);
     ncep = fe_get_output_size(fe);
@@ -139,8 +139,8 @@ create_frames(fe_t *fe, const int16 *data, size_t nsamp)
     cepbuf = ckd_calloc_2d(nfr, ncep, sizeof(**cepbuf));
     inptr = data;
 
-    rv = fe_process(fe, &inptr, &nsamp, cepbuf, &nfr);
-    E_INFO("fe_process produced %d frames, "
+    rv = fe_process_int16(fe, &inptr, &nsamp, cepbuf, &nfr);
+    E_INFO("fe_process_int16 produced %d frames, "
            " %d samples remaining\n", rv, nsamp);
     TEST_EQUAL(rv, 4);
     TEST_EQUAL(nfr, 1);
@@ -163,15 +163,15 @@ create_full(fe_t *fe, const int16 *data, size_t nsamp)
     int rv, nfr, ncep;
     
     TEST_EQUAL(0, fe_start(fe));
-    rv = fe_process(fe, NULL, &nsamp, NULL, &nfr);
+    rv = fe_process_int16(fe, NULL, &nsamp, NULL, &nfr);
     TEST_EQUAL(0, rv);
     TEST_EQUAL(5, nfr);
     ncep = fe_get_output_size(fe);
 
     cepbuf = ckd_calloc_2d(nfr, ncep, sizeof(**cepbuf));
     inptr = data;
-    rv = fe_process(fe, &inptr, &nsamp, cepbuf, &nfr);
-    E_INFO("fe_process produced %d frames, "
+    rv = fe_process_int16(fe, &inptr, &nsamp, cepbuf, &nfr);
+    E_INFO("fe_process_int16 produced %d frames, "
            " %d samples remaining\n", rv, nsamp);
     TEST_EQUAL(rv, 4);
     TEST_EQUAL(nfr, 1);
@@ -195,7 +195,7 @@ create_process_frames(fe_t *fe, const int16 *data, size_t nsamp)
     
     fe_get_input_size(fe, &frame_shift, &frame_size);
     TEST_EQUAL(0, fe_start(fe));
-    rv = fe_process(fe, NULL, &nsamp, NULL, &nfr);
+    rv = fe_process_int16(fe, NULL, &nsamp, NULL, &nfr);
     TEST_EQUAL(0, rv);
     TEST_EQUAL(5, nfr);
     ncep = fe_get_output_size(fe);
@@ -205,7 +205,7 @@ create_process_frames(fe_t *fe, const int16 *data, size_t nsamp)
 
     for (i = 0; i < 4; ++i) {
         nfr = 1;
-        rv = fe_process(fe, &inptr, &nsamp, &cepbuf[i], &nfr);
+        rv = fe_process_int16(fe, &inptr, &nsamp, &cepbuf[i], &nfr);
         E_INFO("frame %d updated inptr %ld remaining nsamp %ld "
                "processed %d remaining nfr %d\n",
                i, inptr - data, nsamp, rv, nfr);
@@ -245,7 +245,7 @@ create_fragments(fe_t *fe, const int16 *data, size_t nsamp)
     
     fe_get_input_size(fe, &frame_shift, &frame_size);
     TEST_EQUAL(0, fe_start(fe));
-    rv = fe_process(fe, NULL, &nsamp, NULL, &nfr);
+    rv = fe_process_int16(fe, NULL, &nsamp, NULL, &nfr);
     TEST_EQUAL(0, rv);
     TEST_EQUAL(5, nfr);
     ncep = fe_get_output_size(fe);
@@ -256,7 +256,7 @@ create_fragments(fe_t *fe, const int16 *data, size_t nsamp)
     /* Process with fragments of unusual size. */
     for (i = 0; (size_t)i < sizeof(fragments) / sizeof(fragments[0]); ++i) {
         size_t fragment = fragments[i];
-        rv = fe_process(fe, &inptr, &fragment, cepptr, &nfr);
+        rv = fe_process_int16(fe, &inptr, &fragment, cepptr, &nfr);
         E_INFO("fragment %d updated inptr %ld remaining nsamp %ld "
                "processed %d remaining nfr %d\n",
                i, inptr - data, fragment, rv, nfr);

--- a/tests/test_fe_float32.c
+++ b/tests/test_fe_float32.c
@@ -1,4 +1,3 @@
-/* -*- c-basic-offset: 4 -*- */
 #include "config.h"
 
 #include <stdio.h>
@@ -13,7 +12,7 @@
 #include "test_macros.h"
 
 /**
- * Create a "reference" MFCC using low-level functions.
+ * Create a "reference" MFCC processing only whole frames
  */
 mfcc_t **
 create_reference(fe_t *fe, float32 *data, size_t nsamp)
@@ -53,7 +52,7 @@ create_reference(fe_t *fe, float32 *data, size_t nsamp)
     if (nfr_output > nfr_full) {
         int last_frame_size = nsamp - nfr_full * frame_shift;
         float32 *last_frame = ckd_calloc(last_frame_size,
-                                         sizeof(*last_frame));
+                                       sizeof(*last_frame));
         E_INFO("frame %d from %d to %d (%d samples)\n",
                nfr_full, nfr_full * frame_shift, nsamp,
                last_frame_size);
@@ -62,6 +61,7 @@ create_reference(fe_t *fe, float32 *data, size_t nsamp)
                last_frame_size * sizeof(*data));
         fe_read_frame_float32(fe, last_frame, last_frame_size);
         fe_write_frame(fe, cepbuf[nfr_full]);
+        ckd_free(last_frame);
     }
 
     for (i = 0; i < 5; ++i) {
@@ -76,6 +76,227 @@ create_reference(fe_t *fe, float32 *data, size_t nsamp)
     return cepbuf;
 }
 
+/**
+ * Create MFCC using shift_frame
+ */
+mfcc_t **
+create_shifted(fe_t *fe, float32 *data, size_t nsamp)
+{
+    int32 frame_shift, frame_size;
+    int nfr_full, nfr_output, ncep, i;
+    mfcc_t **cepbuf;
+    float32 *inptr;
+
+    fe_get_input_size(fe, &frame_shift, &frame_size);
+    /* Number of full frames that can be extracted from the given
+     * number of samples. */
+    nfr_full = 1 + (nsamp - frame_size) / frame_shift;
+    /* Number that will be extracted overall. */
+    if ((size_t)(nfr_full - 1) * frame_shift + frame_size < nsamp)
+        nfr_output = nfr_full + 1;
+    else
+        nfr_output = nfr_full;
+    ncep = fe_get_output_size(fe);
+    cepbuf = ckd_calloc_2d(nfr_output, ncep, sizeof(**cepbuf));
+
+    inptr = data;
+    E_INFO("start inptr = %ld\n", inptr - data);
+    inptr += fe_read_frame_float32(fe, inptr, frame_size);
+    fe_write_frame(fe, cepbuf[0]);
+    E_INFO("after first frame = %ld\n", inptr - data);
+    for (i = 1; i < nfr_output; ++i) {
+        inptr += fe_shift_frame_float32(fe, inptr, data + nsamp - inptr);
+        fe_write_frame(fe, cepbuf[i]);
+        E_INFO("after frame %d = %ld\n", i, inptr - data);
+    }
+    TEST_EQUAL(inptr, data + nsamp);
+
+    for (i = 0; i < nfr_output; ++i) {
+        int j;
+        E_INFO("%d: ", i);
+        for (j = 0; j < ncep; ++j) {
+            E_INFOCONT("%.2f ",
+                       MFCC2FLOAT(cepbuf[i][j]));
+        }
+        E_INFOCONT("\n");
+    }
+    return cepbuf;
+}
+
+mfcc_t **
+create_frames(fe_t *fe, const float32 *data, size_t nsamp)
+{
+    mfcc_t **cepbuf;
+    const float32 *inptr;
+    int rv, nfr, ncep;
+    
+    TEST_EQUAL(0, fe_start_utt(fe));
+    rv = fe_process_float32(fe, NULL, &nsamp, NULL, &nfr);
+    TEST_EQUAL(0, rv);
+    TEST_EQUAL(4, nfr);
+    ncep = fe_get_output_size(fe);
+
+    /* Allow an extra overflow frame. */
+    ++nfr;
+    cepbuf = ckd_calloc_2d(nfr, ncep, sizeof(**cepbuf));
+    inptr = data;
+
+    rv = fe_process_float32(fe, &inptr, &nsamp, cepbuf, &nfr);
+    E_INFO("fe_process_float32 produced %d frames, "
+           " %d samples remaining\n", rv, nsamp);
+    TEST_EQUAL(rv, 4);
+    TEST_EQUAL(nfr, 1);
+    TEST_EQUAL(inptr - data, 1024);
+    TEST_EQUAL(nsamp, 0);
+    /* Should get a frame here due to overflow samples. */
+    rv = fe_end_utt(fe, cepbuf[4], &nfr);
+    E_INFO("fe_end_utt rv %d nfr %d\n", rv, nfr);
+    TEST_EQUAL(rv, 1);
+    TEST_EQUAL(nfr, 0);
+
+    return cepbuf;
+}
+
+mfcc_t **
+create_full(fe_t *fe, const float32 *data, size_t nsamp)
+{
+    mfcc_t **cepbuf;
+    const float32 *inptr;
+    int rv, nfr, ncep;
+    
+    TEST_EQUAL(0, fe_start_utt(fe));
+    rv = fe_process_float32(fe, NULL, &nsamp, NULL, &nfr);
+    TEST_EQUAL(0, rv);
+    TEST_EQUAL(4, nfr);
+    ncep = fe_get_output_size(fe);
+
+    /* Allow an extra overflow frame. */
+    ++nfr;
+    cepbuf = ckd_calloc_2d(nfr, ncep, sizeof(**cepbuf));
+    inptr = data;
+    rv = fe_process_float32(fe, &inptr, &nsamp, cepbuf, &nfr);
+    E_INFO("fe_process_float32 produced %d frames, "
+           " %d samples remaining\n", rv, nsamp);
+    TEST_EQUAL(rv, 4);
+    TEST_EQUAL(nfr, 1);
+    TEST_EQUAL(inptr - data, 1024);
+    TEST_EQUAL(nsamp, 0);
+    /* Should get a frame here due to overflow samples. */
+    rv = fe_end_utt(fe, cepbuf[4], &nfr);
+    E_INFO("fe_end_utt rv %d nfr %d\n", rv, nfr);
+    TEST_EQUAL(rv, 1);
+    TEST_EQUAL(nfr, 0);
+
+    return cepbuf;
+}
+
+mfcc_t **
+create_process_frames(fe_t *fe, const float32 *data, size_t nsamp)
+{
+    mfcc_t **cepbuf;
+    const float32 *inptr;
+    int i, rv, nfr, ncep, frame_shift, frame_size;
+    
+    fe_get_input_size(fe, &frame_shift, &frame_size);
+    TEST_EQUAL(0, fe_start_utt(fe));
+    rv = fe_process_float32(fe, NULL, &nsamp, NULL, &nfr);
+    TEST_EQUAL(0, rv);
+    TEST_EQUAL(4, nfr);
+    ncep = fe_get_output_size(fe);
+
+    /* Allow an extra overflow frame. */
+    ++nfr;
+    cepbuf = ckd_calloc_2d(nfr, ncep, sizeof(**cepbuf));
+    inptr = data;
+
+    for (i = 0; i < 4; ++i) {
+        nfr = 1;
+        rv = fe_process_float32(fe, &inptr, &nsamp, &cepbuf[i], &nfr);
+        E_INFO("frame %d updated inptr %ld remaining nsamp %ld "
+               "processed %d remaining nfr %d\n",
+               i, inptr - data, nsamp, rv, nfr);
+        TEST_EQUAL(rv, 1);
+        TEST_EQUAL(nfr, 0);
+        if (i < 3) {
+            /* Confusingly, it will read an extra frame_shift data
+               in order to make the next frame... */
+            TEST_EQUAL(inptr - data, frame_size + (i + 1) * frame_shift);
+        }
+        else {
+            TEST_EQUAL(inptr - data, 1024);
+        }
+    }
+
+    /* Should get a frame here due to overflow samples. */
+    nfr = 1;
+    rv = fe_end_utt(fe, cepbuf[4], &nfr);
+    E_INFO("fe_end_utt rv %d nfr %d\n", rv, nfr);
+    TEST_EQUAL(rv, 1);
+    TEST_EQUAL(nfr, 0);
+
+    return cepbuf;
+}
+
+
+mfcc_t **
+create_fragments(fe_t *fe, const float32 *data, size_t nsamp)
+{
+    mfcc_t **cepbuf, **cepptr;
+    const float32 *inptr;
+    int i, rv, nfr, ncep, frame_shift, frame_size;
+    /* Should total 1024 :) */
+    size_t fragments[] = {
+        1, 145, 39, 350, 410, 79
+    };
+    
+    fe_get_input_size(fe, &frame_shift, &frame_size);
+    TEST_EQUAL(0, fe_start_utt(fe));
+    rv = fe_process_float32(fe, NULL, &nsamp, NULL, &nfr);
+    TEST_EQUAL(0, rv);
+    TEST_EQUAL(4, nfr);
+    ncep = fe_get_output_size(fe);
+
+    /* Allow an extra overflow frame. */
+    ++nfr;
+    cepptr = cepbuf = ckd_calloc_2d(nfr, ncep, sizeof(**cepbuf));
+    inptr = data;
+
+    /* Process with fragments of unusual size. */
+    for (i = 0; (size_t)i < sizeof(fragments) / sizeof(fragments[0]); ++i) {
+        size_t fragment = fragments[i];
+        rv = fe_process_float32(fe, &inptr, &fragment, cepptr, &nfr);
+        E_INFO("fragment %d updated inptr %ld remaining nsamp %ld "
+               "processed %d remaining nfr %d\n",
+               i, inptr - data, fragment, rv, nfr);
+        TEST_EQUAL(0, fragment);
+        cepptr += rv;
+    }
+
+    /* Should get a frame here due to overflow samples. */
+    nfr = 1;
+    rv = fe_end_utt(fe, cepbuf[4], &nfr);
+    E_INFO("fe_end_utt rv %d nfr %d\n", rv, nfr);
+    TEST_EQUAL(rv, 1);
+
+    return cepbuf;
+}
+
+void
+compare_cepstra(mfcc_t **c1, mfcc_t **c2, int nfr, int ncep)
+{
+    int i, j;
+    for (i = 0; i < nfr; ++i) {
+        E_INFO("%d: ", i);
+        for (j = 0; j < ncep; ++j) {
+            E_INFOCONT("%.2f,%.2f ",
+                       MFCC2FLOAT(c1[i][j]),
+                       MFCC2FLOAT(c2[i][j]));
+            TEST_EQUAL_FLOAT(c1[i][j], c2[i][j]);
+        }
+        E_INFOCONT("\n");
+    }
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -88,11 +309,9 @@ main(int argc, char *argv[])
     fe_t *fe;
     int16 ibuf[1024];
     float32 buf[1024];
-    float32 const *inptr;
     int32 frame_shift, frame_size;
-    mfcc_t **cepbuf, **cepbuf1, **cepbuf2, **cptr;
-    int32 nfr, i;
-    size_t nsamp;
+    mfcc_t **cepbuf, **cepbuf1;
+    size_t i;
 
     err_set_loglevel_str("INFO");
     TEST_ASSERT(config = cmd_ln_parse_r(NULL, fe_args, argc, argv, FALSE));
@@ -102,152 +321,39 @@ main(int argc, char *argv[])
 
     fe_get_input_size(fe, &frame_shift, &frame_size);
     TEST_EQUAL(frame_shift, DEFAULT_FRAME_SHIFT);
-    TEST_EQUAL(frame_size, (int)(DEFAULT_WINDOW_LENGTH*DEFAULT_SAMPLING_RATE));
+    TEST_EQUAL(frame_size, (int)(DEFAULT_WINDOW_LENGTH
+                                 * DEFAULT_SAMPLING_RATE));
+
 
     TEST_ASSERT(raw = fopen(TESTDATADIR "/goforward.raw", "rb"));
     TEST_EQUAL(1024, fread(ibuf, sizeof(int16), 1024, raw));
     for (i = 0; i < 1024; ++i)
-	buf[i] = ibuf[i] / 32768.0;
+        buf[i] = ibuf[i] / FLOAT32_SCALE;
 
     E_INFO("Creating reference features\n");
     cepbuf = create_reference(fe, buf, 1024);
+ 
+    E_INFO("Creating features with frame_shift\n");
+    cepbuf1 = create_shifted(fe, buf, 1024);
+    compare_cepstra(cepbuf, cepbuf1, 5, DEFAULT_NUM_CEPSTRA);
+    ckd_free_2d(cepbuf1);
 
-    TEST_EQUAL(0, fe_start_utt(fe));
-    nsamp = 1024;
-    TEST_ASSERT(fe_process_frames_float32(fe, NULL, &nsamp, NULL, &nfr) >= 0);
-    TEST_EQUAL(1024, nsamp);
-    TEST_EQUAL(4, nfr);
+    E_INFO("Creating features with full buffer\n");
+    cepbuf1 = create_full(fe, buf, 1024);
+    compare_cepstra(cepbuf, cepbuf1, 5, DEFAULT_NUM_CEPSTRA);
+    ckd_free_2d(cepbuf1);
 
-    cepbuf1 = ckd_calloc_2d(5, DEFAULT_NUM_CEPSTRA, sizeof(**cepbuf1));
-    inptr = &buf[0];
-    nfr = 1;
+    E_INFO("Creating features with individual frames\n");
+    cepbuf1 = create_process_frames(fe, buf, 1024);
+    compare_cepstra(cepbuf, cepbuf1, 5, DEFAULT_NUM_CEPSTRA);
+    ckd_free_2d(cepbuf1);
 
-    /* Process the data, one frame at a time. */
-    E_INFO("Testing one frame at a time (1024 samples)\n");
-    E_INFO("frame_size %d frame_shift %d\n", frame_size, frame_shift);
-    TEST_ASSERT(fe_process_frames_float32(fe, &inptr, &nsamp, &cepbuf1[0], &nfr) >= 0);
-    E_INFO("updated inptr %ld remaining nsamp %ld processed nfr %d\n",
-	   inptr - buf, nsamp, nfr);
-    TEST_EQUAL(nfr, 1);
-    TEST_EQUAL(inptr - buf, frame_size + frame_shift);
-
-    nfr = 1;
-    TEST_ASSERT(fe_process_frames_float32(fe, &inptr, &nsamp, &cepbuf1[1], &nfr) >= 0);
-    E_INFO("updated inptr %ld remaining nsamp %ld processed nfr %d\n",
-	   inptr - buf, nsamp, nfr);
-    TEST_EQUAL(nfr, 1);
-    TEST_EQUAL(inptr - buf, frame_size + 2 * frame_shift);
-    
-    nfr = 1;
-    TEST_ASSERT(fe_process_frames_float32(fe, &inptr, &nsamp, &cepbuf1[2], &nfr) >= 0);
-    E_INFO("updated inptr %ld remaining nsamp %ld processed nfr %d\n",
-	   inptr - buf, nsamp, nfr); TEST_EQUAL(nfr, 1);
-    TEST_EQUAL(inptr - buf, frame_size + 3 * frame_shift);
-
-    /* Should consume all the input at this point. */
-    nfr = 1;
-    TEST_ASSERT(fe_process_frames_float32(fe, &inptr, &nsamp, &cepbuf1[3], &nfr) >= 0);
-    E_INFO("updated inptr %ld remaining nsamp %ld processed nfr %d\n",
-	   inptr - buf, nsamp, nfr);
-    TEST_EQUAL(nfr, 1);
-    TEST_EQUAL(inptr - buf, 1024);
-    TEST_EQUAL(nsamp, 0);
-
-    /* Should get a frame here due to overflow samples. */
-    TEST_ASSERT(fe_end_utt(fe, cepbuf1[4], &nfr) >= 0);
-    E_INFO("fe_end_utt nfr %d\n", nfr);
-    TEST_EQUAL(nfr, 1);
-
-    /* Test that the output we get by processing one frame at a time
-     * is exactly the same as what we get from doing them all at once. */
-    E_INFO("Testing all data at once (1024 samples)\n");
-    cepbuf2 = ckd_calloc_2d(5, DEFAULT_NUM_CEPSTRA, sizeof(**cepbuf2));
-    inptr = &buf[0];
-    nfr = 5;
-    nsamp = 1024;
-    TEST_EQUAL(0, fe_start_utt(fe));
-    TEST_ASSERT(fe_process_frames_float32(fe, &inptr, &nsamp, cepbuf2, &nfr) >= 0);
-    E_INFO("fe_process_frames consumed nfr %d frames\n", nfr);
-    TEST_EQUAL(nfr, 4);
-    TEST_EQUAL(inptr - buf, 1024);
-    TEST_EQUAL(nsamp, 0);
-    /* And again, should get a frame here due to overflow samples. */
-    TEST_ASSERT(fe_end_utt(fe, cepbuf2[4], &nfr) >= 0);
-    E_INFO("fe_end_utt nfr %d\n", nfr);
-    TEST_EQUAL(nfr, 1);
-
-    /* output features stored in cepbuf should be the same */
-    for (nfr = 0; nfr < 5; ++nfr) {
-      E_INFO("%d: ", nfr);
-      for (i = 0; i < DEFAULT_NUM_CEPSTRA; ++i) {
-        E_INFOCONT("%.2f,%.2f ",
-		   MFCC2FLOAT(cepbuf1[nfr][i]),
-		   MFCC2FLOAT(cepbuf2[nfr][i]));
-        TEST_EQUAL_FLOAT(cepbuf1[nfr][i], cepbuf2[nfr][i]);
-      }
-      E_INFOCONT("\n");
-    }
-    
-    /* Now, also test to make sure that even if we feed data in
-     * little tiny bits we can still make things work. */
-    E_INFO("Testing inputs smaller than one frame (256 samples)\n");
-    memset(cepbuf2[0], 0, 5 * DEFAULT_NUM_CEPSTRA * sizeof(**cepbuf2));
-    inptr = &buf[0];
-    cptr = &cepbuf2[0];
-    nfr = 5;
-    i = 5;
-    nsamp = 256;
-    TEST_EQUAL(0, fe_start_utt(fe));
-    /* Process up to 5 frames (that will not happen) */
-    TEST_ASSERT(fe_process_frames_float32(fe, &inptr, &nsamp, cptr, &i) >= 0);
-    E_INFO("updated inptr %ld remaining nsamp %ld processed nfr %d\n",
-	   inptr - buf, nsamp, i);
-    cptr += i;
-    /* Process up to however many frames are left to make 5 */
-    nfr -= i;
-    i = nfr;
-    nsamp = 256;
-    TEST_ASSERT(fe_process_frames_float32(fe, &inptr, &nsamp, cptr, &i) >= 0);
-    E_INFO("updated inptr %ld remaining nsamp %ld processed nfr %d\n",
-	   inptr - buf, nsamp, i);
-    cptr += i;
-    nfr -= i;
-    i = nfr;
-    nsamp = 256;
-    TEST_ASSERT(fe_process_frames_float32(fe, &inptr, &nsamp, cptr, &i) >= 0);
-    E_INFO("updated inptr %ld remaining nsamp %ld processed nfr %d\n",
-	   inptr - buf, nsamp, i);
-    cptr += i;
-    nfr -= i;
-    i = nfr;
-    nsamp = 256;
-    TEST_ASSERT(fe_process_frames_float32(fe, &inptr, &nsamp, cptr, &i) >= 0);
-    E_INFO("updated inptr %ld remaining nsamp %ld processed nfr %d\n",
-	   inptr - buf, nsamp, i);
-    cptr += i;
-    nfr -= i;
-    E_INFO("nfr %d\n", nfr);
-    /* We processed 1024 bytes, which should give us 4 frames */
-    TEST_EQUAL(nfr, 1);
-    TEST_ASSERT(fe_end_utt(fe, *cptr, &nfr) >= 0);
-    E_INFO("nfr %d\n", nfr);
-    TEST_EQUAL(nfr, 1);
-
-    /* output features stored in cepbuf should be the same */
-    for (nfr = 0; nfr < 5; ++nfr) {
-      E_INFO("%d: ", nfr);
-      for (i = 0; i < DEFAULT_NUM_CEPSTRA; ++i) {
-        E_INFOCONT("%.2f,%.2f ",
-		   MFCC2FLOAT(cepbuf1[nfr][i]),
-		   MFCC2FLOAT(cepbuf2[nfr][i]));
-        TEST_EQUAL_FLOAT(cepbuf1[nfr][i], cepbuf2[nfr][i]);
-      }
-      E_INFOCONT("\n");
-    }
+    E_INFO("Creating features with individual frames\n");
+    cepbuf1 = create_fragments(fe, buf, 1024);
+    compare_cepstra(cepbuf, cepbuf1, 5, DEFAULT_NUM_CEPSTRA);
+    ckd_free_2d(cepbuf1);
 
     ckd_free_2d(cepbuf);
-    ckd_free_2d(cepbuf1);
-    ckd_free_2d(cepbuf2);
     fclose(raw);
     fe_free(fe);
     cmd_ln_free_r(config);

--- a/tests/test_fe_float32.c
+++ b/tests/test_fe_float32.c
@@ -5,11 +5,76 @@
 #include <string.h>
 
 #include <soundswallower/fe.h>
+#include <soundswallower/fe_internal.h>
 #include <soundswallower/err.h>
 #include <soundswallower/cmd_ln.h>
 #include <soundswallower/ckd_alloc.h>
 
 #include "test_macros.h"
+
+/**
+ * Create a "reference" MFCC using low-level functions.
+ */
+mfcc_t **
+create_reference(fe_t *fe, float32 *data, size_t nsamp)
+{
+    int32 frame_shift, frame_size;
+    int nfr_full, nfr_output, ncep, i;
+    mfcc_t **cepbuf;
+
+    fe_get_input_size(fe, &frame_shift, &frame_size);
+    /* Number of full frames that can be extracted from the given
+     * number of samples. */
+    nfr_full = 1 + (nsamp - frame_size) / frame_shift;
+    E_INFO("1 + (%d samples - %d frame_size) / %d frame_shift = %d\n",
+           nsamp, frame_size, frame_shift, nfr_full);
+    /* Number that will be extracted overall. */
+    if ((size_t)(nfr_full - 1) * frame_shift + frame_size < nsamp) {
+        nfr_output = nfr_full + 1;
+        E_INFO("%d extra samples, nfr = %d\n",
+               nsamp - ((nfr_full - 1) * frame_shift + frame_size),
+               nfr_output);
+    }
+    else {
+        nfr_output = nfr_full;
+    }
+    ncep = fe_get_output_size(fe);
+    E_INFO("ncep = %d\n", ncep);
+    cepbuf = ckd_calloc_2d(nfr_output, ncep, sizeof(**cepbuf));
+
+    for (i = 0; i < nfr_full; ++i) {
+        E_INFO("frame %d from %d to %d\n",
+               i, i * frame_shift, i * frame_shift + frame_size);
+        fe_read_frame_float32(fe, data + (i * frame_shift), frame_size);
+        fe_write_frame(fe, cepbuf[i]);
+    }
+
+    /* Create the last frame explicitly to ensure no lossage. */
+    if (nfr_output > nfr_full) {
+        int last_frame_size = nsamp - nfr_full * frame_shift;
+        float32 *last_frame = ckd_calloc(last_frame_size,
+                                         sizeof(*last_frame));
+        E_INFO("frame %d from %d to %d (%d samples)\n",
+               nfr_full, nfr_full * frame_shift, nsamp,
+               last_frame_size);
+        memcpy(last_frame,
+               data + nfr_full * frame_shift,
+               last_frame_size * sizeof(*data));
+        fe_read_frame_float32(fe, last_frame, last_frame_size);
+        fe_write_frame(fe, cepbuf[nfr_full]);
+    }
+
+    for (i = 0; i < 5; ++i) {
+        int j;
+        E_INFO("%d: ", i);
+        for (j = 0; j < ncep; ++j) {
+            E_INFOCONT("%.2f ",
+                       MFCC2FLOAT(cepbuf[i][j]));
+        }
+        E_INFOCONT("\n");
+    }
+    return cepbuf;
+}
 
 int
 main(int argc, char *argv[])
@@ -25,13 +90,12 @@ main(int argc, char *argv[])
     float32 buf[1024];
     float32 const *inptr;
     int32 frame_shift, frame_size;
-    mfcc_t **cepbuf1, **cepbuf2, **cptr;
+    mfcc_t **cepbuf, **cepbuf1, **cepbuf2, **cptr;
     int32 nfr, i;
     size_t nsamp;
 
     err_set_loglevel_str("INFO");
     TEST_ASSERT(config = cmd_ln_parse_r(NULL, fe_args, argc, argv, FALSE));
-    cmd_ln_set_boolean_r(config, "-input_float32", TRUE);
     TEST_ASSERT(fe = fe_init(config));
 
     TEST_EQUAL(fe_get_output_size(fe), DEFAULT_NUM_CEPSTRA);
@@ -41,12 +105,14 @@ main(int argc, char *argv[])
     TEST_EQUAL(frame_size, (int)(DEFAULT_WINDOW_LENGTH*DEFAULT_SAMPLING_RATE));
 
     TEST_ASSERT(raw = fopen(TESTDATADIR "/goforward.raw", "rb"));
-
-    TEST_EQUAL(0, fe_start_utt(fe));
     TEST_EQUAL(1024, fread(ibuf, sizeof(int16), 1024, raw));
     for (i = 0; i < 1024; ++i)
 	buf[i] = ibuf[i] / 32768.0;
 
+    E_INFO("Creating reference features\n");
+    cepbuf = create_reference(fe, buf, 1024);
+
+    TEST_EQUAL(0, fe_start_utt(fe));
     nsamp = 1024;
     TEST_ASSERT(fe_process_frames_float32(fe, NULL, &nsamp, NULL, &nfr) >= 0);
     TEST_EQUAL(1024, nsamp);
@@ -179,6 +245,7 @@ main(int argc, char *argv[])
       E_INFOCONT("\n");
     }
 
+    ckd_free_2d(cepbuf);
     ckd_free_2d(cepbuf1);
     ckd_free_2d(cepbuf2);
     fclose(raw);

--- a/tests/test_fe_float32.c
+++ b/tests/test_fe_float32.c
@@ -130,14 +130,12 @@ create_frames(fe_t *fe, const float32 *data, size_t nsamp)
     const float32 *inptr;
     int rv, nfr, ncep;
     
-    TEST_EQUAL(0, fe_start_utt(fe));
+    TEST_EQUAL(0, fe_start(fe));
     rv = fe_process_float32(fe, NULL, &nsamp, NULL, &nfr);
     TEST_EQUAL(0, rv);
     TEST_EQUAL(4, nfr);
     ncep = fe_get_output_size(fe);
 
-    /* Allow an extra overflow frame. */
-    ++nfr;
     cepbuf = ckd_calloc_2d(nfr, ncep, sizeof(**cepbuf));
     inptr = data;
 
@@ -149,8 +147,8 @@ create_frames(fe_t *fe, const float32 *data, size_t nsamp)
     TEST_EQUAL(inptr - data, 1024);
     TEST_EQUAL(nsamp, 0);
     /* Should get a frame here due to overflow samples. */
-    rv = fe_end_utt(fe, cepbuf[4], &nfr);
-    E_INFO("fe_end_utt rv %d nfr %d\n", rv, nfr);
+    rv = fe_end(fe, cepbuf[4], &nfr);
+    E_INFO("fe_end rv %d nfr %d\n", rv, nfr);
     TEST_EQUAL(rv, 1);
     TEST_EQUAL(nfr, 0);
 
@@ -164,14 +162,12 @@ create_full(fe_t *fe, const float32 *data, size_t nsamp)
     const float32 *inptr;
     int rv, nfr, ncep;
     
-    TEST_EQUAL(0, fe_start_utt(fe));
+    TEST_EQUAL(0, fe_start(fe));
     rv = fe_process_float32(fe, NULL, &nsamp, NULL, &nfr);
     TEST_EQUAL(0, rv);
-    TEST_EQUAL(4, nfr);
+    TEST_EQUAL(5, nfr);
     ncep = fe_get_output_size(fe);
 
-    /* Allow an extra overflow frame. */
-    ++nfr;
     cepbuf = ckd_calloc_2d(nfr, ncep, sizeof(**cepbuf));
     inptr = data;
     rv = fe_process_float32(fe, &inptr, &nsamp, cepbuf, &nfr);
@@ -182,8 +178,8 @@ create_full(fe_t *fe, const float32 *data, size_t nsamp)
     TEST_EQUAL(inptr - data, 1024);
     TEST_EQUAL(nsamp, 0);
     /* Should get a frame here due to overflow samples. */
-    rv = fe_end_utt(fe, cepbuf[4], &nfr);
-    E_INFO("fe_end_utt rv %d nfr %d\n", rv, nfr);
+    rv = fe_end(fe, cepbuf[4], &nfr);
+    E_INFO("fe_end rv %d nfr %d\n", rv, nfr);
     TEST_EQUAL(rv, 1);
     TEST_EQUAL(nfr, 0);
 
@@ -198,14 +194,12 @@ create_process_frames(fe_t *fe, const float32 *data, size_t nsamp)
     int i, rv, nfr, ncep, frame_shift, frame_size;
     
     fe_get_input_size(fe, &frame_shift, &frame_size);
-    TEST_EQUAL(0, fe_start_utt(fe));
+    TEST_EQUAL(0, fe_start(fe));
     rv = fe_process_float32(fe, NULL, &nsamp, NULL, &nfr);
     TEST_EQUAL(0, rv);
-    TEST_EQUAL(4, nfr);
+    TEST_EQUAL(5, nfr);
     ncep = fe_get_output_size(fe);
 
-    /* Allow an extra overflow frame. */
-    ++nfr;
     cepbuf = ckd_calloc_2d(nfr, ncep, sizeof(**cepbuf));
     inptr = data;
 
@@ -229,8 +223,8 @@ create_process_frames(fe_t *fe, const float32 *data, size_t nsamp)
 
     /* Should get a frame here due to overflow samples. */
     nfr = 1;
-    rv = fe_end_utt(fe, cepbuf[4], &nfr);
-    E_INFO("fe_end_utt rv %d nfr %d\n", rv, nfr);
+    rv = fe_end(fe, cepbuf[4], &nfr);
+    E_INFO("fe_end rv %d nfr %d\n", rv, nfr);
     TEST_EQUAL(rv, 1);
     TEST_EQUAL(nfr, 0);
 
@@ -250,14 +244,12 @@ create_fragments(fe_t *fe, const float32 *data, size_t nsamp)
     };
     
     fe_get_input_size(fe, &frame_shift, &frame_size);
-    TEST_EQUAL(0, fe_start_utt(fe));
+    TEST_EQUAL(0, fe_start(fe));
     rv = fe_process_float32(fe, NULL, &nsamp, NULL, &nfr);
     TEST_EQUAL(0, rv);
-    TEST_EQUAL(4, nfr);
+    TEST_EQUAL(5, nfr);
     ncep = fe_get_output_size(fe);
 
-    /* Allow an extra overflow frame. */
-    ++nfr;
     cepptr = cepbuf = ckd_calloc_2d(nfr, ncep, sizeof(**cepbuf));
     inptr = data;
 
@@ -274,8 +266,8 @@ create_fragments(fe_t *fe, const float32 *data, size_t nsamp)
 
     /* Should get a frame here due to overflow samples. */
     nfr = 1;
-    rv = fe_end_utt(fe, cepbuf[4], &nfr);
-    E_INFO("fe_end_utt rv %d nfr %d\n", rv, nfr);
+    rv = fe_end(fe, cepbuf[4], &nfr);
+    E_INFO("fe_end rv %d nfr %d\n", rv, nfr);
     TEST_EQUAL(rv, 1);
 
     return cepbuf;
@@ -348,7 +340,7 @@ main(int argc, char *argv[])
     compare_cepstra(cepbuf, cepbuf1, 5, DEFAULT_NUM_CEPSTRA);
     ckd_free_2d(cepbuf1);
 
-    E_INFO("Creating features with individual frames\n");
+    E_INFO("Creating features with oddly sized fragments\n");
     cepbuf1 = create_fragments(fe, buf, 1024);
     compare_cepstra(cepbuf, cepbuf1, 5, DEFAULT_NUM_CEPSTRA);
     ckd_free_2d(cepbuf1);

--- a/tests/test_fe_float32.c
+++ b/tests/test_fe_float32.c
@@ -306,7 +306,7 @@ create_mixed_fragments(fe_t *fe, const float32 *data, const int16 *idata, size_t
             iinptr += (inptr - data) - (iinptr - idata);
         }
         else {
-            rv = fe_process(fe, &iinptr, &fragment, cepptr, &nfr);
+            rv = fe_process_int16(fe, &iinptr, &fragment, cepptr, &nfr);
             inptr += (iinptr - idata) - (inptr - data);
         }
         E_INFO("%s fragment %d updated inptr %ld %ld remaining nsamp %ld "

--- a/tests/test_feat_fe.c
+++ b/tests/test_feat_fe.c
@@ -60,7 +60,7 @@ main(int argc, char *argv[])
 			cptr += ncep;
 		}
 	}
-	fe_end(fe, *cptr, &nfr);
+	fe_end(fe, cptr, &nfr);
 
 	/* Now test some feature extraction problems. */
 	featbuf1 = feat_array_alloc(fcb, total_frames);

--- a/tests/test_feat_fe.c
+++ b/tests/test_feat_fe.c
@@ -44,12 +44,12 @@ main(int argc, char *argv[])
 	nsamp = ftell(raw) / sizeof(int16);
 	fe_process(fe, NULL, &nsamp, NULL, &total_frames);
 	printf("%ld samples, %d + 1 frames\n", nsamp, total_frames);
-	total_frames++; /* For the possible fe_end_utt() frame */
+	total_frames++; /* For the possible fe_end() frame */
 	cepbuf = ckd_calloc_2d(total_frames + 1, fe_get_output_size(fe), sizeof(**cepbuf));
 	fseek(raw, 0, SEEK_SET);
 
         /* fe_process_frames() had a BAD API so I changed it */
-	fe_start_utt(fe);
+	fe_start(fe);
 	cptr = cepbuf;
 	nfr = total_frames;
 	while ((nsamp = fread(buf, sizeof(int16), 2048, raw)) > 0) {
@@ -60,7 +60,7 @@ main(int argc, char *argv[])
 			cptr += ncep;
 		}
 	}
-	fe_end_utt(fe, *cptr, &nfr);
+	fe_end(fe, *cptr, &nfr);
 
 	/* Now test some feature extraction problems. */
 	featbuf1 = feat_array_alloc(fcb, total_frames);

--- a/tests/test_feat_fe.c
+++ b/tests/test_feat_fe.c
@@ -42,23 +42,22 @@ main(int argc, char *argv[])
 	/* Determine how much data and how many MFCC frames we need. */
 	fseek(raw, 0, SEEK_END);
 	nsamp = ftell(raw) / sizeof(int16);
-	fe_process_frames(fe, NULL, &nsamp, NULL, &total_frames);
+	fe_process(fe, NULL, &nsamp, NULL, &total_frames);
 	printf("%ld samples, %d + 1 frames\n", nsamp, total_frames);
 	total_frames++; /* For the possible fe_end_utt() frame */
 	cepbuf = ckd_calloc_2d(total_frames + 1, fe_get_output_size(fe), sizeof(**cepbuf));
 	fseek(raw, 0, SEEK_SET);
 
-	/* Pay close attention, kids.  This is how you use fe_process_frames(). */
+        /* fe_process_frames() had a BAD API so I changed it */
 	fe_start_utt(fe);
 	cptr = cepbuf;
 	nfr = total_frames;
 	while ((nsamp = fread(buf, sizeof(int16), 2048, raw)) > 0) {
 		int16 const *bptr = buf;
 		while (nsamp) {
-			int32 ncep = nfr;
-			fe_process_frames(fe, &bptr, &nsamp, cptr, &ncep);
+			int ncep = fe_process(fe, &bptr, &nsamp,
+                                              cptr, &nfr);
 			cptr += ncep;
-			nfr -= ncep;
 		}
 	}
 	fe_end_utt(fe, *cptr, &nfr);

--- a/tests/test_feat_fe.c
+++ b/tests/test_feat_fe.c
@@ -42,7 +42,7 @@ main(int argc, char *argv[])
 	/* Determine how much data and how many MFCC frames we need. */
 	fseek(raw, 0, SEEK_END);
 	nsamp = ftell(raw) / sizeof(int16);
-	fe_process(fe, NULL, &nsamp, NULL, &total_frames);
+	fe_process_int16(fe, NULL, &nsamp, NULL, &total_frames);
 	printf("%ld samples, %d + 1 frames\n", nsamp, total_frames);
 	total_frames++; /* For the possible fe_end() frame */
 	cepbuf = ckd_calloc_2d(total_frames + 1, fe_get_output_size(fe), sizeof(**cepbuf));
@@ -55,8 +55,8 @@ main(int argc, char *argv[])
 	while ((nsamp = fread(buf, sizeof(int16), 2048, raw)) > 0) {
 		int16 const *bptr = buf;
 		while (nsamp) {
-			int ncep = fe_process(fe, &bptr, &nsamp,
-                                              cptr, &nfr);
+			int ncep = fe_process_int16(fe, &bptr, &nsamp,
+                                                    cptr, &nfr);
 			cptr += ncep;
 		}
 	}

--- a/tests/test_ps.c
+++ b/tests/test_ps.c
@@ -70,9 +70,9 @@ ps_decoder_test(cmd_ln_t *config, char const *sname, char const *expected)
     cepbuf = ckd_calloc_2d(nfr + 1,
                    fe_get_output_size(ps->acmod->fe),
                    sizeof(**cepbuf));
-    fe_start_utt(ps->acmod->fe);
+    fe_start(ps->acmod->fe);
     fe_process_frames(ps->acmod->fe, &bptr, &nsamps, cepbuf, &nfr);
-    fe_end_utt(ps->acmod->fe, cepbuf[nfr], &i);
+    fe_end(ps->acmod->fe, cepbuf[nfr], &i);
 
     /* Decode it with process_cep() */
     TEST_EQUAL(0, ps_start_utt(ps));


### PR DESCRIPTION
Refactor the fe code somewhat and remove the bogus -float32_input config option.  We can just mix float and int inputs, though not sure you would want to do that.

BREAKING_CHANGE: Simplifies the fe API somewhat, function names change due to this.  This wasn't an external API though, and in any case we are still in the "API churn" stage.