### PR TITLE
Work around Windows damage, run CI on lesser platforms

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,10 +27,10 @@ jobs:
         uses: actions/checkout@v3
       - name: Install
         run: |
-          pip install -r requirements.dev.txt
-          pip install .
+          pip3 install -r requirements.dev.txt
+          pip3 install .
       - name: Run tests
-        run: pytest
+        run: python3 -m pytest
   wintest:
     runs-on: windows-latest
     steps:
@@ -38,10 +38,10 @@ jobs:
         uses: actions/checkout@v3
       - name: Install
         run: |
-          pip install -r requirements.dev.txt
-          pip install .
+          pip3 install -r requirements.dev.txt
+          pip3 install .
       - name: Run tests
-        run: pytest
+        run: python3 -m pytest
   mactest:
     runs-on: macos-latest
     steps:
@@ -52,7 +52,7 @@ jobs:
           pip3 install -r requirements.dev.txt
           pip3 install .
       - name: Run tests
-        run: pytest
+        run: python3 -m pytest
   nodetest:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,28 @@ jobs:
           pip install .
       - name: Run tests
         run: pytest
+  wintest:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install
+        run: |
+          pip install -r requirements.dev.txt
+          pip install .
+      - name: Run tests
+        run: pytest
+  mactest:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install
+        run: |
+          pip install -r requirements.dev.txt
+          pip install .
+      - name: Run tests
+        run: pytest
   nodetest:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,8 +49,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Install
         run: |
-          pip install -r requirements.dev.txt
-          pip install .
+          pip3 install -r requirements.dev.txt
+          pip3 install .
       - name: Run tests
         run: pytest
   nodetest:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ include(CheckSymbolExists)
 include(CheckLibraryExists)
 include(TestBigEndian)
 
-project(soundswallower VERSION 0.4.0
+project(soundswallower VERSION 0.4.1
   DESCRIPTION "An even smaller speech recognizer")
 
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,12 +9,12 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 [tool.cibuildwheel]
-# Build the versions found in Ubuntu LTS, the stable PyPy, and 3.10
-# everywhere else
+# Build the versions found in Ubuntu LTS, the stable PyPy, Anaconda on Windows
 build = [
       "pp38*",
       "cp36-manylinux_*",
       "cp38-manylinux_*",
+	  "cp39-win*",
       "cp310-*"
 ]
 # PyPy 3.8 will choke on CPython 3.8 build leftovers...

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = soundswallower
-version = 0.4.0
+version = 0.4.1
 description = An even smaller speech recognizer
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/decoder.c
+++ b/src/decoder.c
@@ -71,6 +71,11 @@ expand_file_config(config_t *config, const char *arg,
     }
 }
 #else
+#ifdef WIN32
+#define PATHSEP "\\"
+#else
+#define PATHSEP "/"
+#endif
 static int
 file_exists(const char *path)
 {
@@ -87,7 +92,7 @@ expand_file_config(config_t *config, const char *arg,
 {
     const char *val;
     if ((val = config_str(config, arg)) == NULL) {
-        char *tmp = string_join(hmmdir, "/", file, NULL);
+        char *tmp = string_join(hmmdir, PATHSEP, file, NULL);
         if (file_exists(tmp))
 	    config_set_str(config, arg, tmp);
 	else

--- a/src/decoder.c
+++ b/src/decoder.c
@@ -129,9 +129,10 @@ config_expand(config_t *config)
 #else
     /* Look for feat_params.json in acoustic model dir. */
     if ((featparams = config_str(config, "featparams")) != NULL) {
-        FILE *json = fopen(featparams, "rt");
+        /* Open in binary mode so fread() matches ftell() on Windows */
+        FILE *json = fopen(featparams, "rb");
         char *jsontxt;
-        size_t len;
+        size_t len, rv;
 
         if (json == NULL)
             return;
@@ -143,8 +144,9 @@ config_expand(config_t *config)
         }
         jsontxt = malloc(len + 1);
         jsontxt[len] = '\0';
-        if (fread(jsontxt, 1, len, json) != len) {
-            E_ERROR_SYSTEM("Failed to read %s", featparams);
+        if ((rv = fread(jsontxt, 1, len, json)) != len) {
+            E_ERROR_SYSTEM("Failed to read %s (got %zu not %zu)",
+                           featparams, rv, len);
             ckd_free(jsontxt);
             return;
         }


### PR DESCRIPTION
I guess it's C Programming 101, but I had not realized that the size of a text file on Windows is not the same as the return value from fread() in text mode.  There's no reason to open JSON in text mode anyway since we don't care about line endings.

Also run Python tests (the ones that matter) on Windows and MacOS to ensure this doesn't happen again.