### PR TITLE
Make the API less asynchronous

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ include(CheckSymbolExists)
 include(CheckLibraryExists)
 include(TestBigEndian)
 
-project(soundswallower VERSION 0.4.3
+project(soundswallower VERSION 0.5.0
   DESCRIPTION "An even smaller speech recognizer")
 
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)

--- a/js/README.md
+++ b/js/README.md
@@ -1,27 +1,24 @@
-SoundSwallower: an even smaller speech recognizer
-=================================================
+# SoundSwallower: an even smaller speech recognizer
 
 > "Time and change have a voice; eternity is silent. The human ear is
 > always searching for one or the other."<br>
-> Leena Krohn, *Datura, or a delusion we all see*
+> Leena Krohn, _Datura, or a delusion we all see_
 
-SoundSwallower is a refactored version of PocketSphinx intended for
-embedding in web applications.  The goal is not to provide a fast
-implementation of large-vocabulary continuous speech recognition, but
-rather to provide a *small*, *asynchronous* implementation of simple,
-useful speech technologies.
+SoundSwallower is a refactored version of PocketSphinx intended for embedding in
+web applications. The goal is not to provide a fast implementation of
+large-vocabulary continuous speech recognition, but rather to provide a _small_
+implementation of simple, useful speech technologies.
 
 With that in mind the current version is limited to finite-state
 grammar recognition.
 
-Installation
-------------
+## Installation
 
 SoundSwallower can be installed in your NPM project:
 
     # From the Internets
     npm install soundswallower
-    
+
 You can also build and install it from source, provided you have
 Emscripten and CMake installed:
 
@@ -88,11 +85,10 @@ Look at the [SoundSwallower-Demo
 repository](https://github.com/dhdaines/soundswallower-demo) for an
 example.
 
-Basic Usage
------------
+## Basic Usage
 
 The entire package is contained within a module compiled by
-Emscripten.  The NPM package includes only the compiled code, but you
+Emscripten. The NPM package includes only the compiled code, but you
 can rebuild it yourself using [the full source code from
 GitHub](https://github.com/ReadAlongs/SoundSwallower) which also
 includes C and Python implementations.
@@ -103,54 +99,43 @@ that returns a promise that is fulfilled with the actual module once
 the WASM code is fully loaded:
 
 ```js
-const ssjs = await require('soundswallower')();
+const ssjs = await require("soundswallower")();
 ```
 
 Once you figure out how to get the module, you can try to initialize
 the recognizer and recognize some speech.
 
-Great, so let's initialize the recognizer.  Anything that changes the
-state of the recognizer is an async function.  So everything except
-getting the current recognition result.  We follow the
-construct-then-initialize pattern:
+Great, so let's initialize the recognizer. This possibly involves some long I/O
+operations so it's asynchronous. We follow the construct-then-initialize
+pattern. You can use `Promise`s too of course.
 
 ```js
 let decoder = new ssjs.Decoder({
-    loglevel: "INFO",
-    backtrace: true
+  loglevel: "INFO",
+  backtrace: true,
 });
 await decoder.initialize();
 ```
 
 The optional `loglevel` and `backtrace` options will make it a bit
-more verbose, so you can be sure it's actually doing something.  Now
-we will create and enable the world's stupidest grammar, which
-recognizes one sentence:
+more verbose, so you can be sure it's actually doing something.
+
+The simplest use case is to recognize some text we already know, which is called
+"force alignment". In this case you set this text, which must already be
+preprocessed to be a whitespace-separated string containing only words in the
+dictionary, using `set_align_text`:
 
 ```js
-await decoder.set_fsg("goforward", 0, 4, [
-    {from: 0, to: 1, prob: 1.0, word: "go"},
-    {from: 1, to: 2, prob: 1.0, word: "forward"},
-    {from: 2, to: 3, prob: 1.0, word: "ten"},
-    {from: 3, to: 4, prob: 1.0, word: "meters"}
-]);
-```
-
-If you actually want to just recognize a single sentence, in order to
-get time alignments (this is known as "force-alignment"), we have a
-better method for you:
-
-```js
-await decoder.set_align_text("go forward ten meters");
+decoder.set_align_text("go forward ten meters");
 ```
 
 It is also possible to parse a grammar in
 [JSGF](https://en.wikipedia.org/wiki/JSGF) format, see below for an
 example.
 
-Okay, let's wreck a nice beach!  Record yourself saying something,
+Okay, let's wreck a nice beach! Record yourself saying something,
 preferably the sentence "go forward ten meters", using SoX, for
-example.  Note that we record at 44.1kHz in 32-bit floating point
+example. Note that we record at 44.1kHz in 32-bit floating point
 format as this is the default under JavaScript (due to WebAudio
 limitations).
 
@@ -162,13 +147,13 @@ Now you can load it and recognize it with:
 
 ```js
 let audio = await fs.readFile("goforward.raw");
-await decoder.start();
-await decoder.process(audio, false, true);
-await decoder.stop();
+decoder.start();
+decoder.process(audio, false, true);
+decoder.stop();
 ```
 
 The results can be obtained with `get_hyp()` or in a more detailed
-format with time alignments using `get_hypseg()`.  These are not
+format with time alignments using `get_hypseg()`. These are not
 asynchronous methods, as they do not depend on or change the state of
 the decoder:
 
@@ -178,19 +163,19 @@ console.log(decoder.get_hypseg());
 ```
 
 If you want even more detailed segmentation (phone and HMM state
-level) you can use `get_alignment_json`.  For more detail on this
+level) you can use `get_alignment_json`. For more detail on this
 format, see [the PocketSphinx
 documentation](https://github.com/cmusphinx/pocketsphinx#usage) as it
-is borrowed from there.  Since this is JSON, you can create an object
+is borrowed from there. Since this is JSON, you can create an object
 from it and iterate over it:
 
 ```js
-const result = JSON.parse(await decoder.get_alignment_json());
+const result = JSON.parse(decoder.get_alignment_json());
 for (const word of result.w) {
-    console.log(`word ${word.t} at ${word.b} has duration ${word.d}`);
-    for (const phone of word.w) {
-        console.log(`phone ${phone.t} at ${phone.b} has duration ${phone.d}`);
-    }
+  console.log(`word ${word.t} at ${word.b} has duration ${word.d}`);
+  for (const phone of word.w) {
+    console.log(`phone ${phone.t} at ${phone.b} has duration ${phone.d}`);
+  }
 }
 ```
 
@@ -202,47 +187,44 @@ awful:
 decoder.delete();
 ```
 
-Loading models
---------------
+## Loading models
 
 By default, SoundSwallower will use a not particularly good acoustic
-model and a reasonable dictionary for US English.  A model for French
+model and a reasonable dictionary for US English. A model for French
 is also available, which you can load by default by setting the
 `defaultModel` property in the module object before loading:
 
 ```js
 const ssjs = {
-	defaultModel: "fr-fr"
+  defaultModel: "fr-fr",
 };
-await require('soundswallower')(ssjs);
+await require("soundswallower")(ssjs);
 ```
 
 The default model is expected to live under the `model/` directory
 relative to the current web page (on the web) or the `soundswallower`
-module (in Node.js).  You can modify this by setting the `modelBase`
+module (in Node.js). You can modify this by setting the `modelBase`
 property in the module object when loading, e.g.:
 
 ```js
 const ssjs = {
-	modelBase: "/assets/models/", /* Trailing slash is necessary */
-	defaultModel: "fr-fr",
+  modelBase: "/assets/models/" /* Trailing slash is necessary */,
+  defaultModel: "fr-fr",
 };
-await require('soundswallower')(ssjs);
+await require("soundswallower")(ssjs);
 ```
 
 This is simply concatenated to the model name, so you should make sure
 to include the trailing slash, e.g. "model/" and not "model"!
 
+## Using grammars
 
-Using grammars
---------------
-
-We currently support JSGF for writing grammars.  You can parse one
+We currently support JSGF for writing grammars. You can parse one
 from a JavaScript string and set it in the decoder like this (a
 hypothetical pizza-ordering grammar):
 
 ```js
-    await decoder.set_jsgf(`#JSGF V1.0;
+decoder.set_jsgf(`#JSGF V1.0;
 grammar pizza;
 public <order> = [<greeting>] [<want>] [<quantity>] [<size>] [pizza] <toppings>;
 <greeting> = hi | hello | yo | howdy;
@@ -255,27 +237,28 @@ public <order> = [<greeting>] [<want>] [<quantity>] [<size>] [pizza] <toppings>;
 ```
 
 Note that all the words in the grammar must first be defined in the
-dictionary.  You can add custom dictionary words using the `add_word`
+dictionary. You can add custom dictionary words using the `add_word`
 method on the `Decoder` object, as long as you speak ArpaBet (or
-whatever phoneset the acoustic model uses).  IPA and
+whatever phoneset the acoustic model uses). IPA and
 grapheme-to-phoneme support may become possible in the near future.
 If you are going to add a bunch of words, pass `false` as the third
 argument for all but the last one, as this will delay the reloading of
 the internal state.
 
 ```js
-    await decoder.add_word("supercalifragilisticexpialidocious",
-	    "S UW P ER K AE L IH F R AE JH IH L IH S T IH K EH K S P IY AE L IH D OW SH Y UH S");
+decoder.add_word(
+  "supercalifragilisticexpialidocious",
+  "S UW P ER K AE L IH F R AE JH IH L IH S T IH K EH K S P IY AE L IH D OW SH Y UH S"
+);
 ```
 
-Voice activity detection / Endpointing
---------------------------------------
+## Voice activity detection / Endpointing
 
 This is a work in progress, but it is also possible to detect the
 start and end of speech in an input stream using an `Endpointer`
-object.  This requires you to pass buffers of a specific size, which
-is understandably difficult since WebAudio also only wants to *give*
-you buffers of a specific (and entirely different) size.  A better
+object. This requires you to pass buffers of a specific size, which
+is understandably difficult since WebAudio also only wants to _give_
+you buffers of a specific (and entirely different) size. A better
 example is forthcoming but it looks a bit like this (copied directly
 from [the
 documentation](https://soundswallower.readthedocs.io/en/latest/soundswallower.js.html#Endpointer.get_in_speech):
@@ -285,14 +268,12 @@ let prev_in_speech = ep.get_in_speech();
 let frame_size = ep.get_frame_size();
 // Presume `frame` is a Float32Array of frame_size or less
 let speech;
-if (frame.size < frame_size)
-    speech = ep.end_stream(frame);
-else
-    speech = ep.process(frame);
+if (frame.size < frame_size) speech = ep.end_stream(frame);
+else speech = ep.process(frame);
 if (speech !== null) {
-    if (!prev_in_speech)
-        console.log("Speech started at " + ep.get_speech_start());
-    if (!ep.get_in_speech())
-        console.log("Speech ended at " + ep.get_speech_end());
+  if (!prev_in_speech)
+    console.log("Speech started at " + ep.get_speech_start());
+  if (!ep.get_in_speech())
+    console.log("Speech ended at " + ep.get_speech_end());
 }
 ```

--- a/js/api.js
+++ b/js/api.js
@@ -604,7 +604,7 @@ class Decoder {
         shape,
         shape + 4
       );
-      Module.free(shape);
+      Module._free(shape);
     }
     if (cpfeats == 0) throw new Error("Spectrogram calculation failed");
     Module._free(pcm_addr);

--- a/js/api.js
+++ b/js/api.js
@@ -339,10 +339,9 @@ class Decoder {
   }
 
   /**
-   * Start processing input asynchronously.
-   * @returns {Promise} Promise resolved once processing is started.
+   * Start processing input.
    */
-  async start() {
+  start() {
     this.assert_initialized();
     if (Module._decoder_start_utt(this.cdecoder) < 0) {
       throw new Error("Failed to start utterance processing");
@@ -350,10 +349,9 @@ class Decoder {
   }
 
   /**
-   * Finish processing input asynchronously.
-   * @returns {Promise} Promise resolved once processing is finished.
+   * Finish processing input.
    */
-  async stop() {
+  stop() {
     this.assert_initialized();
     if (Module._decoder_end_utt(this.cdecoder) < 0) {
       throw new Error("Failed to stop utterance processing");
@@ -361,13 +359,12 @@ class Decoder {
   }
 
   /**
-   * Process a block of audio data asynchronously.
+   * Process a block of audio data.
    * @param {Float32Array} pcm Audio data, in float32 format, in
    * the range [-1.0, 1.0].
-   * @returns {Promise<number>} Promise resolved to the number of
-   * frames processed.
+   * @returns Number of frames processed.
    */
-  async process(pcm, no_search = false, full_utt = false) {
+  process(pcm, no_search = false, full_utt = false) {
     this.assert_initialized();
     const pcm_bytes = pcm.length * pcm.BYTES_PER_ELEMENT;
     const pcm_addr = Module._malloc(pcm_bytes);
@@ -434,7 +431,7 @@ class Decoder {
    *                    alignments, 2 for phone and state alignments.
    * @returns JSON with a detailed word and phone-level alignment.
    */
-  async get_alignment_json(start = 0.0, align_level = 1) {
+  get_alignment_json(start = 0.0, align_level = 1) {
     this.assert_initialized();
     /* FIXME: This could block for some time, decompose it. */
     const cjson = Module._decoder_result_json(
@@ -461,14 +458,13 @@ class Decoder {
   }
 
   /**
-   * Add a word to the pronunciation dictionary asynchronously.
+   * Add a word to the pronunciation dictionary.
    * @param {string} word Text of word to add.
    * @param {string} pron Pronunciation of word as space-separated list of phonemes.
    * @param {number} update Update decoder immediately (set to
    * false when adding a list of words, except for the last word).
-   * @returns {Promise} Promise resolved once word has been added.
    */
-  async add_word(word, pron, update = true) {
+  add_word(word, pron, update = true) {
     this.assert_initialized();
     const cword = allocateUTF8(word);
     const cpron = allocateUTF8(pron);
@@ -487,7 +483,7 @@ class Decoder {
   }
 
   /**
-   * Set recognition grammar from a list of transitions asynchronously.
+   * Set recognition grammar from a list of transitions.
    * @param {string} name Name of grammar.
    * @param {number} start_state Index of starting state.
    * @param {number} final_state Index of ending state.
@@ -495,7 +491,7 @@ class Decoder {
    * of which is an Object with the keys `from`, `to`, `word`, and
    * `prob`.  The word must exist in the dictionary.
    */
-  async set_fsg(name, start_state, final_state, transitions) {
+  set_fsg(name, start_state, final_state, transitions) {
     this.assert_initialized();
     const logmath = Module._decoder_logmath(this.cdecoder);
     const config = Module._decoder_config(this.cdecoder);
@@ -543,7 +539,7 @@ class Decoder {
    * @param {string} [toprule] Name of starting rule for grammar,
    * if not specified, the first public rule will be used.
    */
-  async set_jsgf(jsgf_string, toprule = null) {
+  set_jsgf(jsgf_string, toprule = null) {
     this.assert_initialized();
     const logmath = Module._decoder_logmath(this.cdecoder);
     const config = Module._decoder_config(this.cdecoder);
@@ -573,7 +569,7 @@ class Decoder {
    *                        words.  All words must be present in the
    *                        dictionary.
    */
-  async set_align_text(text) {
+  set_align_text(text) {
     this.assert_initialized();
     const ctext = allocateUTF8(text);
     const rv = Module._decoder_set_align_text(this.cdecoder, ctext);
@@ -587,7 +583,7 @@ class Decoder {
    * @returns {Promise<FeatureBuffer>} Promise resolved to an object
    * containing `data`, `nfr`, and `nfeat` properties.
    */
-  async spectrogram(pcm) {
+  spectrogram(pcm) {
     this.assert_initialized();
     const cfe = Module._decoder_fe(this.cdecoder);
     if (cfe == 0) throw new Error("Could not get front end from decoder");

--- a/js/api.js
+++ b/js/api.js
@@ -595,22 +595,20 @@ class Decoder {
     const pcm_u8 = new Uint8Array(pcm.buffer, pcm.byteOffset, pcm_bytes);
     writeArrayToMemory(pcm_u8, pcm_addr);
     /* Note, pointers and size_t are 4 bytes */
-    {
-      const shape = Module._malloc(8);
-      const cpfeats = Module._spectrogram(
-        cfe,
-        pcm_addr,
-        pcm_bytes / 4,
-        shape,
-        shape + 4
-      );
-      Module._free(shape);
-    }
+    const shape = Module._malloc(8);
+    const cpfeats = Module._spectrogram(
+      cfe,
+      pcm_addr,
+      pcm_bytes / 4,
+      shape,
+      shape + 4
+    );
     if (cpfeats == 0) throw new Error("Spectrogram calculation failed");
     Module._free(pcm_addr);
     const cfeats = getValue(cpfeats, "*");
     const nfr = getValue(shape, "*");
     const nfeat = getValue(shape + 4, "*");
+    Module._free(shape);
     const data = new Float32Array(
       /* This copies the data, which is what we want. */
       HEAP8.slice(cfeats, cfeats + nfr * nfeat * 4).buffer

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
    "name": "soundswallower",
-   "version": "0.4.3",
+   "version": "0.5.0",
    "description": "An even smaller speech recognizer",
    "main": "soundswallower.js",
    "scripts": {

--- a/js/soundswallower.d.ts
+++ b/js/soundswallower.d.ts
@@ -9,27 +9,27 @@ export class Decoder {
   has_config(key: string): boolean;
   initialize(): Promise<any>;
   reinitialize_audio(): Promise<void>;
-  start(): Promise<void>;
-  stop(): Promise<void>;
+  start(): void;
+  stop(): void;
   process(
     pcm: Float32Array | Uint8Array,
     no_search?: boolean,
     full_utt?: boolean
-  ): Promise<number>;
+  ): number;
   get_hyp(): string;
   get_hypseg(): Array<Segment>;
-  get_alignment_json(start?: number, align_level?: number): Promise<string>;
+  get_alignment_json(start?: number, align_level?: number): string;
   lookup_word(word: string): string;
-  add_word(word: string, pron: string, update?: boolean): Promise<number>;
+  add_word(word: string, pron: string, update?: boolean): number;
   set_fsg(
     name: string,
     start_state: number,
     final_state: number,
     transitions: Array<Transition>
-  ): Promise<void>;
-  set_jsgf(jsgf_string: string, toprule?: string): Promise<void>;
-  set_align_text(text: string): Promise<void>;
-  spectrogram(pcm: Float32Array | Uint8Array): Promise<FeatureBuffer>;
+  ): void;
+  set_jsgf(jsgf_string: string, toprule?: string): void;
+  set_align_text(text: string): void;
+  spectrogram(pcm: Float32Array | Uint8Array): FeatureBuffer;
 }
 export class Endpointer {
   get_frame_size(): number;

--- a/js/soundswallower.d.ts
+++ b/js/soundswallower.d.ts
@@ -1,67 +1,80 @@
 /// <reference types="emscripten" />
 export class Decoder {
-    initialized: boolean;
-    delete(): void;
-    get_config_json(): string;
-    set_config(key: string, val: string|number): boolean;
-    unset_config(key: string): void;
-    get_config(key: string): string|number;
-    has_config(key: string): boolean;
-    initialize(): Promise<any>;
-    reinitialize_audio(): Promise<void>;
-    start(): Promise<void>;
-    stop(): Promise<void>;
-    process(pcm: Float32Array|Uint8Array, no_search?: boolean, full_utt?: boolean): Promise<number>;
-    get_hyp(): string;
-    get_hypseg(): Array<Segment>;
-    get_alignment_json(start?: number, align_level?: number): Promise<string>;
-    lookup_word(word: string): string;
-    add_word(word: string, pron: string, update?: boolean): Promise<number>;
-    set_fsg(name: string, start_state: number, final_state: number,
-            transitions: Array<Transition>): Promise<void>;
-    set_jsgf(jsgf_string: string, toprule?: string): Promise<void>;
-    set_align_text(text: string): Promise<void>;
-    spectrogram(pcm: Float32Array|Uint8Array): Promise<FeatureBuffer>;
+  initialized: boolean;
+  delete(): void;
+  get_config_json(): string;
+  set_config(key: string, val: string | number): boolean;
+  unset_config(key: string): void;
+  get_config(key: string): string | number;
+  has_config(key: string): boolean;
+  initialize(): Promise<any>;
+  reinitialize_audio(): Promise<void>;
+  start(): Promise<void>;
+  stop(): Promise<void>;
+  process(
+    pcm: Float32Array | Uint8Array,
+    no_search?: boolean,
+    full_utt?: boolean
+  ): Promise<number>;
+  get_hyp(): string;
+  get_hypseg(): Array<Segment>;
+  get_alignment_json(start?: number, align_level?: number): Promise<string>;
+  lookup_word(word: string): string;
+  add_word(word: string, pron: string, update?: boolean): Promise<number>;
+  set_fsg(
+    name: string,
+    start_state: number,
+    final_state: number,
+    transitions: Array<Transition>
+  ): Promise<void>;
+  set_jsgf(jsgf_string: string, toprule?: string): Promise<void>;
+  set_align_text(text: string): Promise<void>;
+  spectrogram(pcm: Float32Array | Uint8Array): Promise<FeatureBuffer>;
 }
 export class Endpointer {
-    get_frame_size(): number;
-    get_frame_length(): number;
-    get_in_speech(): boolean;
-    get_speech_start(): number;
-    get_speech_end(): number;
-    process(frame: Float32Array): Float32Array;
-    end_stream(frame: Float32Array): Float32Array;
+  get_frame_size(): number;
+  get_frame_length(): number;
+  get_in_speech(): boolean;
+  get_speech_start(): number;
+  get_speech_end(): number;
+  process(frame: Float32Array): Float32Array;
+  end_stream(frame: Float32Array): Float32Array;
 }
 export interface Transition {
-    from: number;
-    to: number;
-    prob?: number;
-    word?: string;
+  from: number;
+  to: number;
+  prob?: number;
+  word?: string;
 }
 export interface Segment {
-    start: number;
-    end: number;
-    word: string;
+  start: number;
+  end: number;
+  word: string;
 }
 export interface Config {
-    [key: string]: string|number|boolean;
+  [key: string]: string | number | boolean;
 }
 export interface FeatureBuffer {
-    data: Float32Array;
-    nfr: number;
-    nfeat: number;
+  data: Float32Array;
+  nfr: number;
+  nfeat: number;
 }
 
 export interface SoundSwallowerModule extends EmscriptenModule {
-    get_model_path(subpath: string): string;
-    load_json(path: string): any;
-    Decoder: {
-        new(config?: Config): Decoder;
-    }
-    Endpointer: {
-        new(sample_rate: number, frame_length?: number,
-            mode?: number, window?: number, ratio?: number): Endpointer;
-    }
+  get_model_path(subpath: string): string;
+  load_json(path: string): any;
+  Decoder: {
+    new (config?: Config): Decoder;
+  };
+  Endpointer: {
+    new (
+      sample_rate: number,
+      frame_length?: number,
+      mode?: number,
+      window?: number,
+      ratio?: number
+    ): Endpointer;
+  };
 }
 declare const createModule: EmscriptenModuleFactory<SoundSwallowerModule>;
 export default createModule;

--- a/js/test_typescript.ts
+++ b/js/test_typescript.ts
@@ -1,55 +1,54 @@
 /* -*- javascript -*- */
 import soundswallower_factory from "./soundswallower.js";
-import {SoundSwallowerModule, Decoder, Segment} from "./soundswallower.js";
-import {promises as fs} from "fs";
+import { SoundSwallowerModule, Decoder, Segment } from "./soundswallower.js";
+import { promises as fs } from "fs";
 import * as assert from "assert";
 
 (async () => {
-    const soundswallower: SoundSwallowerModule = await soundswallower_factory();
-    /* Basic test */
-    const decoder: Decoder = new soundswallower.Decoder({
-	fsg: "testdata/goforward.fsg",
-	samprate: 16000,
-    });
-    await decoder.initialize();
-    let pcm: Uint8Array = await fs.readFile("testdata/goforward-float32.raw");
-    await decoder.start();
-    await decoder.process(pcm, false, true);
-    await decoder.stop();
-    let hyp: string = decoder.get_hyp();
-    console.log(`recognized: ${hyp}`);
-    assert.equal("go forward ten meters", hyp);
-    let hypseg: Array<Segment> = decoder.get_hypseg();
-    let hypseg_words = [];
-    for (const seg of hypseg) {
-	assert.ok(seg.end >= seg.start);
-        if (seg.word != "<sil>" && seg.word != "(NULL)")
-	    hypseg_words.push(seg.word);
-    }
-    assert.deepStrictEqual(hypseg_words,
-			   ["go", "forward", "ten", "meters"]);
+  const soundswallower: SoundSwallowerModule = await soundswallower_factory();
+  /* Basic test */
+  const decoder: Decoder = new soundswallower.Decoder({
+    fsg: "testdata/goforward.fsg",
+    samprate: 16000,
+  });
+  await decoder.initialize();
+  let pcm: Uint8Array = await fs.readFile("testdata/goforward-float32.raw");
+  decoder.start();
+  decoder.process(pcm, false, true);
+  decoder.stop();
+  let hyp: string = decoder.get_hyp();
+  console.log(`recognized: ${hyp}`);
+  assert.equal("go forward ten meters", hyp);
+  let hypseg: Array<Segment> = decoder.get_hypseg();
+  let hypseg_words = [];
+  for (const seg of hypseg) {
+    assert.ok(seg.end >= seg.start);
+    if (seg.word != "<sil>" && seg.word != "(NULL)")
+      hypseg_words.push(seg.word);
+  }
+  assert.deepStrictEqual(hypseg_words, ["go", "forward", "ten", "meters"]);
 
-    /* Test create_fsg */
-    await decoder.add_word("_go", "G OW", false);
-    await decoder.add_word("_forward", "F AO R W ER D", false);
-    await decoder.add_word("_ten", "T EH N", false);
-    await decoder.add_word("_meters", "M IY T ER Z", true);
-    await decoder.set_fsg("goforward", 0, 4, [
-	{from: 0, to: 1, prob: 1.0, word: "_go"},
-	{from: 1, to: 2, prob: 1.0, word: "_forward"},
-	{from: 2, to: 3, prob: 1.0, word: "_ten"},
-	{from: 3, to: 4, prob: 1.0, word: "_meters"}
-    ]);
-    pcm = await fs.readFile("testdata/goforward-float32.raw");
-    await decoder.start();
-    await decoder.process(pcm, false, true);
-    await decoder.stop();
-    hyp = decoder.get_hyp();
-    console.log(`recognized: ${hyp}`);
-    assert.equal("_go _forward _ten _meters", hyp);
+  /* Test create_fsg */
+  decoder.add_word("_go", "G OW", false);
+  decoder.add_word("_forward", "F AO R W ER D", false);
+  decoder.add_word("_ten", "T EH N", false);
+  decoder.add_word("_meters", "M IY T ER Z", true);
+  decoder.set_fsg("goforward", 0, 4, [
+    { from: 0, to: 1, prob: 1.0, word: "_go" },
+    { from: 1, to: 2, prob: 1.0, word: "_forward" },
+    { from: 2, to: 3, prob: 1.0, word: "_ten" },
+    { from: 3, to: 4, prob: 1.0, word: "_meters" },
+  ]);
+  pcm = await fs.readFile("testdata/goforward-float32.raw");
+  decoder.start();
+  decoder.process(pcm, false, true);
+  decoder.stop();
+  hyp = decoder.get_hyp();
+  console.log(`recognized: ${hyp}`);
+  assert.equal("_go _forward _ten _meters", hyp);
 
-    /* Test JSGF */
-    await decoder.set_jsgf(`#JSGF V1.0;
+  /* Test JSGF */
+  decoder.set_jsgf(`#JSGF V1.0;
 grammar pizza;
 public <order> = [<greeting>] [<want>] [<quantity>] [<size>] [<style>]
        [(pizza | pizzas)] [<toppings>];
@@ -61,11 +60,11 @@ public <order> = [<greeting>] [<want>] [<quantity>] [<size>] [<style>]
 <toppings> = [with] <topping> ([and] <topping>)*;
 <topping> = pepperoni | ham | olives | mushrooms | tomatoes | (green | hot) peppers | pineapple;
 `);
-    pcm = await fs.readFile("testdata/pizza-float32.raw");
-    await decoder.start();
-    await decoder.process(pcm, false, true);
-    await decoder.stop();
-    hyp = decoder.get_hyp();
-    console.log(`recognized: ${hyp}`);
-    assert.equal("yo gimme four large all dressed pizzas", hyp);
+  pcm = await fs.readFile("testdata/pizza-float32.raw");
+  decoder.start();
+  decoder.process(pcm, false, true);
+  decoder.stop();
+  hyp = decoder.get_hyp();
+  console.log(`recognized: ${hyp}`);
+  assert.equal("yo gimme four large all dressed pizzas", hyp);
 })();

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = soundswallower
-version = 0.4.3
+version = 0.5.0
 description = An even smaller speech recognizer
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
Perhaps it's common knowledge to JavaScript programmers but `async` and `await` are *not* general purpose coroutines, that is to say, an `async` function does not necessarily suspend execution on each `await` in the sense of unblocking the main event loop.  This is because Promises run on the "microtask queue" and the browser will keep running them until there are no more left before it goes back to doing important things like responding to user input: https://developer.mozilla.org/en-US/docs/Web/API/HTML_DOM_API/Microtask_guide#microtasks

Obviously if you launch a bunch of async functions or Promises they will yield to *each other* but that is not actually what you want in most cases.

Concretely this means that using `async` for *CPU-bound* APIs is considered harmful (tm).  So we have to remove `async` from most functions in the API.

Conversely, for *IO-bound* APIs it is considered useful (tm).  So initialization will definitely remain async/promise based.