### PR TITLE
fix: generate py39 wheels too

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,12 +49,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
       - name: Install
         run: |
-          pip3 install -r requirements.dev.txt
-          pip3 install .
+          pip install -r requirements.dev.txt
+          pip install .
       - name: Run tests
-        run: python3 -m pytest
+        run: python -m pytest
   nodetest:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install
         run: |
           sudo apt-get install sox ninja-build
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install
         run: |
           pip3 install -r requirements.dev.txt
@@ -37,7 +37,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install
         run: |
           pip3 install -r requirements.dev.txt
@@ -48,7 +48,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install
         run: |
           pip3 install -r requirements.dev.txt
@@ -59,9 +59,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Build Dependencies
-        uses: mymindstorm/setup-emsdk@v12
+        uses: mymindstorm/setup-emsdk@v14
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build
         run: |
           emcmake cmake -S . -B jsbuild

--- a/js/linker_options.txt
+++ b/js/linker_options.txt
@@ -6,4 +6,3 @@
 -sSTRICT=1
 -sSTRICT_JS=0
 -sSUPPORT_LONGJMP=0
---memory-init-file=0

--- a/js/package.json
+++ b/js/package.json
@@ -40,6 +40,7 @@
   "homepage": "https://github.com/ReadAlongs/SoundSwallower#readme",
   "devDependencies": {
     "@types/node": "^18.0.3",
+    "@types/markdown-it": "^14.1.1",
     "chai": "^4.3.7",
     "jsdoc": "^3.6.10",
     "mocha": "^10.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ soundswallower = "soundswallower.cli:main"
 # Build a reduced selection of binaries as there are tons of them
 build = [
       "cp38-*",
+      "cp39-*",
       "cp310-*",
       "cp311-*",
       "cp312-*",


### PR DESCRIPTION
The absence of 
soundswallower-0.6.4-cp39-cp39-win_amd64.whl on pypi means I (and therefore Studio CLI users) cannot install ReadAlongs/Studio on my windows machine using Python 3.9 without installing the MS Visual Studio compiler. So add py39 wheels to pyproject.toml so they're generated next time we release.

<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Enable simple ReadAlongs/Studio installation on Windows with Python 3.9

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

The fact that `pip install -e .` in ReadAlongs/Studio currently fails on Windows with a fresh Python 3.9 environment unless the Visual Studio compiler is installed.

### Feedback sought? <!-- What should reviewers focus on in particular? -->

Sanity check

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

low

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

ok

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

<!-- Add any other relevant information here -->
