### PR TITLE
chore: bump black and mypy to most recent with py 3.8 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,11 +9,11 @@ repos:
     -   id: check-yaml
     -   id: check-added-large-files
 - repo: https://github.com/psf/black
-  rev: 24.3.0
+  rev: 24.8.0
   hooks:
     - id: black
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.991
+    rev: v1.13.0
     hooks:
     -   id: mypy
 - repo: https://github.com/PyCQA/isort

--- a/py/soundswallower/cli.py
+++ b/py/soundswallower/cli.py
@@ -68,7 +68,6 @@ def make_argparse() -> argparse.ArgumentParser:
     grammars.add_argument("-t", "--align-text", help="Input text for force alignment.")
     grammars.add_argument("-g", "--grammar", help="Grammar file for recognition.")
     grammars.add_argument("-f", "--fsg", help="FSG file for recognition.")
-    parser.add_argument_group(grammars)
     return parser
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,9 +36,9 @@ dev = [
     "pytest",
     "numpy",
     "pre-commit",
-    "black==24.3.0",
+    "black==24.8.0",
     "isort",
-    "mypy==0.991",
+    "mypy==1.13.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
Removed line
    parser.add_argument_group(grammars)
which a) was never meant to be allowed,
and b) isn't required anyway, it doesn't actually do anything.

See the deprecation note in
https://docs.python.org/3/library/argparse.html#argparse.ArgumentParser.add_argument_group

<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

just keeping the repo tidy, in the same spirit as #68 and #70

### Feedback sought? <!-- What should reviewers focus on in particular? -->

rubber stamping

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

low

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

n/a

### How to test? <!-- Explain how reviewers should test this PR. -->

Run `pre-commit run --all-files` and see no warnings anymore

Run `soundswallower -h`, `soundswallower -a foo -t bar` and see that the mutually exclusive group still works.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

<!-- Add any other relevant information here -->
