### PR TITLE
pre-commit: Ignore mypy error on argparse

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v5.0.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -17,12 +17,12 @@ repos:
     hooks:
     -   id: mypy
 - repo: https://github.com/PyCQA/isort
-  rev: 5.11.4
+  rev: 5.13.2
   hooks:
     - id: isort
       args: [--profile=black]
 -   repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v15.0.7
+    rev: v19.1.5
     hooks:
     - id: clang-format
       types_or: [c++, c]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,11 +9,11 @@ repos:
     -   id: check-yaml
     -   id: check-added-large-files
 - repo: https://github.com/psf/black
-  rev: 24.3.0
+  rev: 24.8.0
   hooks:
     - id: black
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.991
+    rev: v1.13.0
     hooks:
     -   id: mypy
 - repo: https://github.com/PyCQA/isort

--- a/include/soundswallower/bitvec.h
+++ b/include/soundswallower/bitvec.h
@@ -96,7 +96,7 @@ bitvec_t *bitvec_realloc(bitvec_t *vec, /* In: Bit vector to search */
  * @param n is the number of bits
  */
 
-#define bitvec_set_all(v, n) memset(v, (bitvec_t)-1, \
+#define bitvec_set_all(v, n) memset(v, (bitvec_t) - 1, \
                                     (((n) + BITVEC_BITS - 1) / BITVEC_BITS) * sizeof(bitvec_t))
 /**
  * Clear the b-th bit of bit vector v

--- a/include/soundswallower/config_defs.h
+++ b/include/soundswallower/config_defs.h
@@ -64,17 +64,15 @@
         DEBUG_OPTIONS
 
 /** Options for debugging and logging. */
-#define DEBUG_OPTIONS                                                  \
-    { "logfn",                                                         \
-      ARG_STRING,                                                      \
-      NULL,                                                            \
-      "File to write log messages in" },                               \
-    {                                                                  \
-        "loglevel",                                                    \
-            ARG_STRING,                                                \
-            "WARN",                                                    \
-            "Minimum level of log messages (DEBUG, INFO, WARN, ERROR)" \
-    }
+#define DEBUG_OPTIONS                    \
+    { "logfn",                           \
+      ARG_STRING,                        \
+      NULL,                              \
+      "File to write log messages in" }, \
+        { "loglevel",                    \
+          ARG_STRING,                    \
+          "WARN",                        \
+          "Minimum level of log messages (DEBUG, INFO, WARN, ERROR)" }
 
 /** Options defining beam width parameters for tuning the search. */
 #define BEAM_OPTIONS                                                                            \
@@ -86,12 +84,10 @@
           ARG_FLOATING,                                                                         \
           "7e-29",                                                                              \
           "Beam width applied to word exits" },                                                 \
-    {                                                                                           \
-        "pbeam",                                                                                \
-            ARG_FLOATING,                                                                       \
-            "1e-48",                                                                            \
-            "Beam width applied to phone transitions"                                           \
-    }
+        { "pbeam",                                                                              \
+          ARG_FLOATING,                                                                         \
+          "1e-48",                                                                              \
+          "Beam width applied to phone transitions" }
 
 /** Options defining other parameters for tuning the search. */
 #define SEARCH_OPTIONS                                                                          \
@@ -107,12 +103,10 @@
           ARG_BOOLEAN,                                                                          \
           "no",                                                                                 \
           "Print results and backtraces to log." },                                             \
-    {                                                                                           \
-        "maxhmmpf",                                                                             \
-            ARG_INTEGER,                                                                        \
-            "30000",                                                                            \
-            "Maximum number of active HMMs to maintain at each frame (or -1 for no pruning)"    \
-    }
+        { "maxhmmpf",                                                                           \
+          ARG_INTEGER,                                                                          \
+          "30000",                                                                              \
+          "Maximum number of active HMMs to maintain at each frame (or -1 for no pruning)" }
 
 /** Command-line options for finite state grammars. */
 #define FSG_OPTIONS                                               \
@@ -132,12 +126,10 @@
           ARG_BOOLEAN,                                            \
           "yes",                                                  \
           "Add alternate pronunciations to FSG" },                \
-    {                                                             \
-        "fsgusefiller",                                           \
-            ARG_BOOLEAN,                                          \
-            "yes",                                                \
-            "Insert filler words at each state."                  \
-    }
+        { "fsgusefiller",                                         \
+          ARG_BOOLEAN,                                            \
+          "yes",                                                  \
+          "Insert filler words at each state." }
 
 /** Command-line options for statistical language models (not used) and grammars. */
 #define NGRAM_OPTIONS                                                           \
@@ -161,29 +153,25 @@
           ARG_FLOATING,                                                         \
           "0.005",                                                              \
           "Silence word transition probability" },                              \
-    {                                                                           \
-        "fillprob",                                                             \
-            ARG_FLOATING,                                                       \
-            "1e-8",                                                             \
-            "Filler word transition probability"                                \
-    }
+        { "fillprob",                                                           \
+          ARG_FLOATING,                                                         \
+          "1e-8",                                                               \
+          "Filler word transition probability" }
 
 /** Command-line options for dictionaries. */
-#define DICT_OPTIONS                                                                                   \
-    { "dict",                                                                                          \
-      ARG_STRING,                                                                                      \
-      NULL,                                                                                            \
-      "Main pronunciation dictionary (lexicon) input file" },                                          \
-        { "fdict",                                                                                     \
-          ARG_STRING,                                                                                  \
-          NULL,                                                                                        \
-          "Noise word pronunciation dictionary input file" },                                          \
-    {                                                                                                  \
-        "dictcase",                                                                                    \
-            ARG_BOOLEAN,                                                                               \
-            "no",                                                                                      \
-            "Dictionary is case sensitive (NOTE: case insensitivity applies to ASCII characters only)" \
-    }
+#define DICT_OPTIONS                                          \
+    { "dict",                                                 \
+      ARG_STRING,                                             \
+      NULL,                                                   \
+      "Main pronunciation dictionary (lexicon) input file" }, \
+        { "fdict",                                            \
+          ARG_STRING,                                         \
+          NULL,                                               \
+          "Noise word pronunciation dictionary input file" }, \
+        { "dictcase",                                         \
+          ARG_BOOLEAN,                                        \
+          "no",                                               \
+          "Dictionary is case sensitive (NOTE: case insensitivity applies to ASCII characters only)" }
 
 /** Command-line options for acoustic modeling */
 #define ACMOD_OPTIONS                                                                \
@@ -263,12 +251,10 @@
           ARG_FLOATING,                                                              \
           "1.0001",                                                                  \
           "Base in which all log-likelihoods calculated" },                          \
-    {                                                                                \
-        "cionly",                                                                    \
-            ARG_BOOLEAN,                                                             \
-            "no",                                                                    \
-            "Use only context-independent phones (faster, useful for alignment)"     \
-    }
+        { "cionly",                                                                  \
+          ARG_BOOLEAN,                                                               \
+          "no",                                                                      \
+          "Use only context-independent phones (faster, useful for alignment)" }
 
 #if WORDS_BIGENDIAN
 #define NATIVE_ENDIAN "big"
@@ -424,12 +410,10 @@
           ARG_BOOLEAN,                                                                   \
           "no",                                                                          \
           "Remove noise using spectral subtraction" },                                   \
-    {                                                                                    \
-        "verbose",                                                                       \
-            ARG_BOOLEAN,                                                                 \
-            "no",                                                                        \
-            "Show input filenames"                                                       \
-    }
+        { "verbose",                                                                     \
+          ARG_BOOLEAN,                                                                   \
+          "no",                                                                          \
+          "Show input filenames" }
 
 #define FEAT_OPTIONS                                                                                         \
     { "feat",                                                                                                \
@@ -460,12 +444,10 @@
           ARG_INTEGER,                                                                                       \
           "0",                                                                                               \
           "Dimensionality of output of feature transformation (0 to use entire matrix)" },                   \
-    {                                                                                                        \
-        "svspec",                                                                                            \
-            ARG_STRING,                                                                                      \
-            NULL,                                                                                            \
-            "Subvector specification (e.g., 24,0-11/25,12-23/26-38 or 0-12/13-25/26-38)"                     \
-    }
+        { "svspec",                                                                                          \
+          ARG_STRING,                                                                                        \
+          NULL,                                                                                              \
+          "Subvector specification (e.g., 24,0-11/25,12-23/26-38 or 0-12/13-25/26-38)" }
 
 #define CONFIG_EMPTY_OPTION \
     {                       \

--- a/include/soundswallower/fsg_lextree.h
+++ b/include/soundswallower/fsg_lextree.h
@@ -149,7 +149,7 @@ typedef struct fsg_pnode_s {
 #define fsg_pnode_leaf(p) ((p)->leaf)
 #define fsg_pnode_ctxt(p) ((p)->ctxt)
 
-#define fsg_pnode_add_ctxt(p, c) ((p)->ctxt.bv[(c) >> 5] |= (1 << ((c)&0x001f)))
+#define fsg_pnode_add_ctxt(p, c) ((p)->ctxt.bv[(c) >> 5] |= (1 << ((c) & 0x001f)))
 
 /*
  * The following is macroized because its called very frequently

--- a/include/soundswallower/s3types.h
+++ b/include/soundswallower/s3types.h
@@ -64,7 +64,7 @@ extern "C" {
  */
 
 typedef int16 s3cipid_t; /** Ci phone id */
-#define BAD_S3CIPID ((s3cipid_t)-1)
+#define BAD_S3CIPID ((s3cipid_t) - 1)
 #define NOT_S3CIPID(p) ((p) < 0)
 #define IS_S3CIPID(p) ((p) >= 0)
 #define MAX_S3CIPID 32767
@@ -72,7 +72,7 @@ typedef int16 s3cipid_t; /** Ci phone id */
 /*#define MAX_S3CIPID	127*/
 
 typedef int32 s3pid_t; /** Phone id (triphone or ciphone) */
-#define BAD_S3PID ((s3pid_t)-1)
+#define BAD_S3PID ((s3pid_t) - 1)
 #define NOT_S3PID(p) ((p) < 0)
 #define IS_S3PID(p) ((p) >= 0)
 #define MAX_S3PID ((int32)0x7ffffffe)
@@ -84,13 +84,13 @@ typedef uint16 s3ssid_t; /** Senone sequence id (triphone or ciphone) */
 #define MAX_S3SSID ((s3ssid_t)0xfffe)
 
 typedef int32 s3tmatid_t; /** Transition matrix id; there can be as many as pids */
-#define BAD_S3TMATID ((s3tmatid_t)-1)
+#define BAD_S3TMATID ((s3tmatid_t) - 1)
 #define NOT_S3TMATID(t) ((t) < 0)
 #define IS_S3TMATID(t) ((t) >= 0)
 #define MAX_S3TMATID ((int32)0x7ffffffe)
 
 typedef int32 s3wid_t; /** Dictionary word id */
-#define BAD_S3WID ((s3wid_t)-1)
+#define BAD_S3WID ((s3wid_t) - 1)
 #define NOT_S3WID(w) ((w) < 0)
 #define IS_S3WID(w) ((w) >= 0)
 #define MAX_S3WID ((int32)0x7ffffffe)

--- a/py/soundswallower/cli.py
+++ b/py/soundswallower/cli.py
@@ -68,7 +68,7 @@ def make_argparse() -> argparse.ArgumentParser:
     grammars.add_argument("-t", "--align-text", help="Input text for force alignment.")
     grammars.add_argument("-g", "--grammar", help="Grammar file for recognition.")
     grammars.add_argument("-f", "--fsg", help="FSG file for recognition.")
-    parser.add_argument_group(grammars)
+    parser.add_argument_group(grammars)  # type: ignore[arg-type]
     return parser
 
 

--- a/src/hmm.c
+++ b/src/hmm.c
@@ -160,7 +160,7 @@ hmm_normalize(hmm_t *h, int32 bestscr)
         hmm_out_score(h) -= bestscr;
 }
 
-#define hmm_tprob_5st(i, j) (-tp[(i)*6 + (j)])
+#define hmm_tprob_5st(i, j) (-tp[(i) * 6 + (j)])
 #define nonmpx_senscr(i) (-senscore[sseq[i]])
 
 static int32
@@ -477,7 +477,7 @@ hmm_vit_eval_5st_lr_mpx(hmm_t *hmm)
     return bestScore;
 }
 
-#define hmm_tprob_3st(i, j) (-tp[(i)*4 + (j)])
+#define hmm_tprob_3st(i, j) (-tp[(i) * 4 + (j)])
 
 static int32
 hmm_vit_eval_3st_lr(hmm_t *hmm)

--- a/src/ptm_mgau.c
+++ b/src/ptm_mgau.c
@@ -63,9 +63,9 @@ static mgaufuncs_t ptm_mgau_funcs = {
 #define COMPUTE_GMM_MAP(_idx)                       \
     diff[_idx] = obs[_idx] - mean[_idx];            \
     sqdiff[_idx] = MFCCMUL(diff[_idx], diff[_idx]); \
-    compl [_idx] = MFCCMUL(sqdiff[_idx], var[_idx]);
+    compl[_idx] = MFCCMUL(sqdiff[_idx], var[_idx]);
 #define COMPUTE_GMM_REDUCE(_idx) \
-    d = GMMSUB(d, compl [_idx]);
+    d = GMMSUB(d, compl[_idx]);
 
 static void
 insertion_sort_topn(ptm_topn_t *topn, int i, int32 d)
@@ -93,7 +93,7 @@ eval_topn(ptm_mgau_t *s, int cb, int feat, mfcc_t *z)
     ceplen = s->g->featlen[feat];
 
     for (i = 0; i < s->max_topn; i++) {
-        mfcc_t *mean, diff[4], sqdiff[4], compl [4]; /* diff, diff^2, component likelihood */
+        mfcc_t *mean, diff[4], sqdiff[4], compl[4]; /* diff, diff^2, component likelihood */
         mfcc_t *var, d;
         mfcc_t *obs;
         int32 cw, j;
@@ -106,8 +106,8 @@ eval_topn(ptm_mgau_t *s, int cb, int feat, mfcc_t *z)
         for (j = 0; j < ceplen % 4; ++j) {
             diff[0] = *obs++ - *mean++;
             sqdiff[0] = MFCCMUL(diff[0], diff[0]);
-            compl [0] = MFCCMUL(sqdiff[0], *var);
-            d = GMMSUB(d, compl [0]);
+            compl[0] = MFCCMUL(sqdiff[0], *var);
+            d = GMMSUB(d, compl[0]);
             ++var;
         }
         /* We could vectorize this but it's unlikely to make much
@@ -164,7 +164,7 @@ eval_cb(ptm_mgau_t *s, int cb, int feat, mfcc_t *z)
     ceplen = s->g->featlen[feat];
 
     for (detP = det; detP < detE; ++detP) {
-        mfcc_t diff[4], sqdiff[4], compl [4]; /* diff, diff^2, component likelihood */
+        mfcc_t diff[4], sqdiff[4], compl[4]; /* diff, diff^2, component likelihood */
         mfcc_t d, thresh;
         mfcc_t *obs;
         ptm_topn_t *cur;
@@ -181,8 +181,8 @@ eval_cb(ptm_mgau_t *s, int cb, int feat, mfcc_t *z)
         for (j = 0; (j < ceplen % 4) && (d >= thresh); ++j) {
             diff[0] = *obs++ - *mean++;
             sqdiff[0] = MFCCMUL(diff[0], diff[0]);
-            compl [0] = MFCCMUL(sqdiff[0], *var++);
-            d = GMMSUB(d, compl [0]);
+            compl[0] = MFCCMUL(sqdiff[0], *var++);
+            d = GMMSUB(d, compl[0]);
         }
         /* Now do 4 dimensions at a time.  You'd think that GCC would
          * vectorize this?  Apparently not.  And it's right, because

--- a/src/s2_semi_mgau.c
+++ b/src/s2_semi_mgau.c
@@ -75,7 +75,7 @@ eval_topn(s2_semi_mgau_t *s, int32 feat, mfcc_t *z)
     ceplen = s->g->featlen[feat];
 
     for (i = 0; i < s->max_topn; i++) {
-        mfcc_t *mean, diff, sqdiff, compl ; /* diff, diff^2, component likelihood */
+        mfcc_t *mean, diff, sqdiff, compl; /* diff, diff^2, component likelihood */
         vqFeature_t vtmp;
         mfcc_t *var, d;
         mfcc_t *obs;
@@ -90,7 +90,7 @@ eval_topn(s2_semi_mgau_t *s, int32 feat, mfcc_t *z)
             diff = *obs++ - *mean++;
             sqdiff = MFCCMUL(diff, diff);
             compl = MFCCMUL(sqdiff, *var);
-            d = GMMSUB(d, compl );
+            d = GMMSUB(d, compl);
             ++var;
         }
         if (d < (mfcc_t)MAX_NEG_INT32) /* Redundant if FIXED_POINT */
@@ -124,7 +124,7 @@ eval_cb(s2_semi_mgau_t *s, int32 feat, mfcc_t *z)
     ceplen = s->g->featlen[feat];
 
     for (detP = det; detP < detE; ++detP) {
-        mfcc_t diff, sqdiff, compl ; /* diff, diff^2, component likelihood */
+        mfcc_t diff, sqdiff, compl; /* diff, diff^2, component likelihood */
         mfcc_t d;
         mfcc_t *obs;
         vqFeature_t *cur;
@@ -137,7 +137,7 @@ eval_cb(s2_semi_mgau_t *s, int32 feat, mfcc_t *z)
             diff = *obs++ - *mean++;
             sqdiff = MFCCMUL(diff, diff);
             compl = MFCCMUL(sqdiff, *var);
-            d = GMMSUB(d, compl );
+            d = GMMSUB(d, compl);
             ++var;
         }
         if (j < ceplen) {


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Improve testing by updating `psf/black` and `mypy` in pre-commit.
1. The current `psf/black` has issues with Python 3.12.5 and drops support for running Python 3.8 so we will use the previous `24.8.0` release.  https://github.com/psf/black/releases/tag/24.10.0
2. Let's ignore `mypy`'s problem with calling `add_mutually_exclusive_group()` on a mutually exclusive group that was deprecated in Python 3.11.  https://docs.python.org/3/library/argparse.html#mutual-exclusion  That description is as clear as mud to me so instead of modifying the code, it feels safer to have mypy ignore it.

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->



### Feedback sought? <!-- What should reviewers focus on in particular? -->



### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->



### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->



### How to test? <!-- Explain how reviewers should test this PR. -->



### Confidence? <!-- How confident are you that these changes are ready to merge? -->



### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->



<!-- Add any other relevant information here -->
