### PR TITLE
Replace isort with ruff check and black with ruff format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,19 +8,15 @@ repos:
     -   id: end-of-file-fixer
     -   id: check-yaml
     -   id: check-added-large-files
-- repo: https://github.com/psf/black
-  rev: 24.8.0
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.8.3
   hooks:
-    - id: black
+    - id: ruff
+    - id: ruff-format
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.13.0
     hooks:
     -   id: mypy
-- repo: https://github.com/PyCQA/isort
-  rev: 5.13.2
-  hooks:
-    - id: isort
-      args: [--profile=black]
 -   repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v19.1.5
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,7 @@ repos:
   rev: v0.8.3
   hooks:
     - id: ruff
+      args: [ --fix ]
     - id: ruff-format
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.13.0

--- a/docs/gen_config.py
+++ b/docs/gen_config.py
@@ -50,7 +50,7 @@ for arg in kwargs:
     if arg.doc is not None:
         arg_text += arg.doc
     if arg.default is not None:
-        if arg.type == bool:
+        if arg.type is bool:
             default = arg.default == "yes"
         else:
             default = arg.type(arg.default)

--- a/py/soundswallower/__init__.py
+++ b/py/soundswallower/__init__.py
@@ -21,11 +21,13 @@ import os
 import wave
 from typing import Optional, Tuple
 
-from ._soundswallower import Config  # noqa: F401
-from ._soundswallower import Decoder  # noqa: F401
-from ._soundswallower import Endpointer  # noqa: F401
-from ._soundswallower import FsgModel  # noqa: F401
-from ._soundswallower import Vad  # noqa: F401
+from ._soundswallower import (  # noqa: F401
+    Config,
+    Decoder,
+    Endpointer,
+    FsgModel,
+    Vad,
+)
 
 
 def get_model_path(subpath: Optional[str] = None) -> str:

--- a/py/soundswallower/__init__.py
+++ b/py/soundswallower/__init__.py
@@ -87,14 +87,14 @@ Hyp.score.__doc__ = "Best path score."
 Hyp.prob.__doc__ = "Posterior probability of hypothesis (often 1.0, sorry)."
 
 __all__ = [
+    "Arg",
     "Config",
     "Decoder",
-    "FsgModel",
-    "Vad",
     "Endpointer",
-    "Arg",
-    "Seg",
+    "FsgModel",
     "Hyp",
-    "get_model_path",
+    "Seg",
+    "Vad",
     "get_audio_data",
+    "get_model_path",
 ]

--- a/py/soundswallower/__init__.py
+++ b/py/soundswallower/__init__.py
@@ -21,13 +21,7 @@ import os
 import wave
 from typing import Optional, Tuple
 
-from ._soundswallower import (  # noqa: F401
-    Config,
-    Decoder,
-    Endpointer,
-    FsgModel,
-    Vad,
-)
+from ._soundswallower import Config, Decoder, Endpointer, FsgModel, Vad
 
 
 def get_model_path(subpath: Optional[str] = None) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ select = [
   "RUF",  # Ruff-specific rules
   "W",    # pycodestyle whitespace
 ]
+fixable = ["I"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["soundswallower"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ select = [
   "F",    # pyflakes
   "I",    # isort
   "PL",   # pylint
+  "RUF",  # Ruff-specific rules
   "W",    # pycodestyle whitespace
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,12 +33,11 @@ classifiers = [
 
 [project.optional-dependencies]
 dev = [
-    "pytest",
+    "mypy==1.13.0",
     "numpy",
     "pre-commit",
-    "black==24.8.0",
-    "isort",
-    "mypy==1.13.0",
+    "pytest",
+    "ruff",
 ]
 
 [project.urls]
@@ -73,13 +72,21 @@ skip = [
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "universal2", "arm64"]
 
-[tool.isort]
-known_first_party = ["soundswallower"]
-profile = "black"
+[tool.ruff.lint]
+select = [
+  "B",    # flake8-bugbear
+  "BLE",  # flake8-blind-except
+  "C4",   # flake8-comprehensions
+  "C90",  # mccabe code complexity
+  "E",    # pycodestyle errors
+  "F",    # pyflakes
+  "I",    # isort
+  "PL",   # pylint
+  "W",    # pycodestyle whitespace
+]
 
-[tool.flake8]
-extend-ignore = "E203"
-max-line-length = "88"
+[tool.ruff.lint.isort]
+known-first-party = ["soundswallower"]
 
 [tool.scikit-build]
 metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Streamline Python linting and formatting.

https://docs.astral.sh/ruff is an extremely fast Python linter and code formatter, written in Rust. With [over 800 linting rules](https://docs.astral.sh/ruff/rules), ruff can be used to replace [Flake8](https://pypi.org/project/flake8/) (plus dozens of plugins), [Black](https://github.com/psf/black), [isort](https://pypi.org/project/isort/), [pydocstyle](https://pypi.org/project/pydocstyle/), [pyupgrade](https://pypi.org/project/pyupgrade/), [autoflake](https://pypi.org/project/autoflake/), and more, all while executing tens or hundreds of times faster than any individual tool.

Add linting tests for bugbear, comprehensions, code complexity, pylint, etc.

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->



### Feedback sought? <!-- What should reviewers focus on in particular? -->



### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->



### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->



### How to test? <!-- Explain how reviewers should test this PR. -->



### Confidence? <!-- How confident are you that these changes are ready to merge? -->



### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->



<!-- Add any other relevant information here -->
